### PR TITLE
Attribute schema

### DIFF
--- a/metarecord/admin.py
+++ b/metarecord/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 from .models import Action, Attribute, AttributeValue, Function, Phase, Record, RecordType
-from .models.attribute import reload_attribute_schema
+from .models.structural_element import reload_attribute_schema
 
 
 class StructuralElementAdmin(admin.ModelAdmin):

--- a/metarecord/importer/tos.py
+++ b/metarecord/importer/tos.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from openpyxl import load_workbook
 
 from metarecord.models import Action, Attribute, AttributeValue, Function, Phase, Record, RecordType
-from metarecord.models.attribute import reload_attribute_schema
+from metarecord.models.structural_element import reload_attribute_schema
 
 
 class TOSImporter:

--- a/metarecord/models/__init__.py
+++ b/metarecord/models/__init__.py
@@ -3,3 +3,4 @@ from .record import Record, RecordType  # noqa
 from .function import Function  # noqa
 from .phase import Phase  # noqa
 from .attribute import Attribute, AttributeValue  # noqa
+from .structural_element import StructuralElement  # noqa

--- a/metarecord/models/action.py
+++ b/metarecord/models/action.py
@@ -1,13 +1,18 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .base import StructuralElement
 from .phase import Phase
+from .structural_element import StructuralElement
 
 
 class Action(StructuralElement):
     phase = models.ForeignKey(Phase, verbose_name=_('phase'), related_name='actions')
     name = models.CharField(verbose_name=_('name'), max_length=256)
+
+    # Action attribute validation rules, hardcoded at least for now
+    _attribute_validations = {
+        'allowed': ['AdditionalInformation']
+    }
 
     class Meta:
         verbose_name = _('action')

--- a/metarecord/models/attribute.py
+++ b/metarecord/models/attribute.py
@@ -1,34 +1,7 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .base import BaseModel, StructuralElement
-
-
-def reload_attribute_schema():
-    whole_schema = []
-
-    for attribute in Attribute.objects.prefetch_related('values'):
-        attribute_schema = {
-            'name': attribute.identifier,
-            'class': 'CharField',
-            'kwargs': {
-                'max_length': 1024,
-                'blank': True,
-                'null': True,
-                'verbose_name': attribute.name,
-            }
-        }
-
-        values = attribute.values.all()
-        if len(values):
-            choices = [(value.value, value.value) for value in values]
-            attribute_schema['kwargs']['choices'] = choices
-
-        whole_schema.append(attribute_schema)
-
-    for model in StructuralElement.__subclasses__():
-        data_field = model._meta.get_field('attributes')
-        data_field.reload_schema(whole_schema)
+from .base import BaseModel
 
 
 class Attribute(BaseModel):

--- a/metarecord/models/base.py
+++ b/metarecord/models/base.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from django_hstore import hstore
 
 
 class BaseModel(models.Model):
@@ -19,12 +18,3 @@ class BaseModel(models.Model):
 
     class Meta:
         abstract = True
-
-
-class StructuralElement(BaseModel):
-    index = models.PositiveSmallIntegerField(null=True, editable=False, db_index=True)
-    attributes = hstore.DictionaryField(blank=True, null=True)
-
-    class Meta:
-        abstract = True
-        ordering = ('index',)

--- a/metarecord/models/function.py
+++ b/metarecord/models/function.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .base import StructuralElement
+from .structural_element import StructuralElement
 
 
 class Function(StructuralElement):
@@ -9,6 +9,20 @@ class Function(StructuralElement):
     parent = models.ForeignKey('self', verbose_name=_('parent'), related_name='children', blank=True, null=True)
     name = models.CharField(verbose_name=_('name'), max_length=256)
     error_count = models.PositiveIntegerField(default=0)
+
+    # Function attribute validation rules, hardcoded at least for now
+    _attribute_validations = {
+        'allowed': ['PersonalData', 'PublicityClass', 'SecurityPeriod', 'Restriction.SecurityPeriodStart',
+                    'SecurityReason', 'RetentionPeriod', 'RetentionReason', 'RetentionPeriodStart',
+                    'AdditionalInformation'],
+        'required': ['PersonalData', 'PublicityClass', 'SecurityPeriod', 'Restriction.SecurityPeriodStart',
+                     'SecurityReason', 'RetentionPeriod', 'RetentionReason', 'RetentionPeriodStart'],
+        'conditionally_required': {
+            'SecurityPeriod': {'PublicityClass': 'Salassa pidettävä'},
+            'Restriction.SecurityPeriodStart': {'PublicityClass': 'Salassa pidettävä'},
+            'SecurityReason': {'PublicityClass': 'Salassa pidettävä'}
+        }
+    }
 
     class Meta:
         verbose_name = _('function')

--- a/metarecord/models/phase.py
+++ b/metarecord/models/phase.py
@@ -1,13 +1,18 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .base import StructuralElement
 from .function import Function
+from .structural_element import StructuralElement
 
 
 class Phase(StructuralElement):
     function = models.ForeignKey(Function, verbose_name=_('function'), related_name='phases')
     name = models.CharField(verbose_name=_('name'), max_length=256)
+
+    # Phase attribute validation rules, hardcoded at least for now
+    _attribute_validations = {
+        'allowed': ['AdditionalInformation'],
+    }
 
     class Meta:
         verbose_name = _('phase')

--- a/metarecord/models/record.py
+++ b/metarecord/models/record.py
@@ -2,7 +2,8 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from .action import Action
-from .base import BaseModel, StructuralElement
+from .base import BaseModel
+from .structural_element import StructuralElement
 
 
 class RecordType(BaseModel):
@@ -21,6 +22,22 @@ class Record(StructuralElement):
     name = models.CharField(verbose_name=_('type specifier'), max_length=256)
     type = models.ForeignKey(RecordType, verbose_name=_('type'), related_name='records')
     parent = models.ForeignKey('self', verbose_name=_('parent'), related_name='children', null=True, blank=True)
+
+    # Record attribute validation rules, hardcoded at least for now
+    _attribute_validations = {
+        'allowed': ['PersonalData', 'PublicityClass', 'SecurityPeriod', 'Restriction.SecurityPeriodStart',
+                    'SecurityReason', 'RetentionPeriod', 'RetentionReason', 'RetentionPeriodStart',
+                    'AdditionalInformation', 'RetentionPeriodTotal', 'RetentionPeriodOffice', 'InformationSystem',
+                    'SocialSecurityNumber', 'StorageAccountable', 'StorageLocation', 'StorageOrder',
+                    'ProtectionClass', 'AdditionalInformation'],
+        'required': ['PersonalData', 'PublicityClass', 'SecurityPeriod', 'Restriction.SecurityPeriodStart',
+                     'SecurityReason', 'RetentionPeriod', 'RetentionReason', 'RetentionPeriodStart'],
+        'conditionally_required': {
+            'SecurityPeriod': {'PublicityClass': 'Salassa pidettävä'},
+            'Restriction.SecurityPeriodStart': {'PublicityClass': 'Salassa pidettävä'},
+            'SecurityReason': {'PublicityClass': 'Salassa pidettävä'}
+        }
+    }
 
     class Meta:
         verbose_name = _('record')

--- a/metarecord/models/structural_element.py
+++ b/metarecord/models/structural_element.py
@@ -1,0 +1,139 @@
+from django.db import models
+from django_hstore import hstore
+
+from .attribute import Attribute
+from .base import BaseModel
+
+
+class StructuralElement(BaseModel):
+    index = models.PositiveSmallIntegerField(null=True, editable=False, db_index=True)
+    attributes = hstore.DictionaryField(blank=True, null=True)
+
+    _attribute_validations = {
+        'allowed': None,
+        'required': None,
+        'conditionally_required': None,
+    }
+
+    class Meta:
+        abstract = True
+        ordering = ('index',)
+
+    @classmethod
+    def get_attribute_json_schema(cls):
+        return get_attribute_json_schema(**cls._attribute_validations)
+
+
+def reload_attribute_schema():
+    """
+    Reload django-hstore schema for attributes.
+    """
+    whole_schema = []
+
+    for attribute in Attribute.objects.prefetch_related('values'):
+        attribute_schema = {
+            'name': attribute.identifier,
+            'class': 'CharField',
+            'kwargs': {
+                'max_length': 1024,
+                'blank': True,
+                'null': True,
+                'verbose_name': attribute.name,
+            }
+        }
+
+        values = attribute.values.all()
+        if len(values):
+            choices = [(value.value, value.value) for value in values]
+            attribute_schema['kwargs']['choices'] = choices
+
+        whole_schema.append(attribute_schema)
+
+    for model in StructuralElement.__subclasses__():
+        data_field = model._meta.get_field('attributes')
+        data_field.reload_schema(whole_schema)
+
+
+def get_attribute_json_schema(allowed=None, required=None, conditionally_required=None):
+    """
+    Return schema for attributes in JSON schema draft 4 format.
+
+    :param allowed: list of allowed attribute identifiers
+    :param required: list of required attribute identifiers
+    :param conditionally_required: conditionally required attribute, format:
+        {
+            <conditionally required attribute identifier>: {
+                <condition attribute identifier>: <condition attribute value>
+            }
+        }
+    :return: dict containing JSON schema data
+    """
+
+    assert set(allowed or []).issuperset(set(required or [])), '"required" contains value(s) not found in "allowed"'
+
+    properties = {}
+
+    if allowed is None:
+        attributes = Attribute.objects.all()
+    else:
+        attributes = Attribute.objects.filter(identifier__in=allowed)
+
+    existing_identifiers = set()
+
+    for attribute in attributes:
+        existing_identifiers.add(attribute.identifier)
+
+        if attribute.values.exists():
+            enum = []
+            for value in attribute.values.all():
+                enum.append(value.value)
+            properties.update({attribute.identifier: {'enum': enum}})
+        else:
+            properties.update({attribute.identifier: {'type': 'string'}})
+
+    schema = {
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'type': 'object',
+        'properties': properties,
+        'additionalProperties': False,
+    }
+
+    if required:
+        schema['required'] = [attr for attr in required if attr in existing_identifiers]
+
+    if conditionally_required:
+        all_of = []
+
+        for required_attribute, condition in conditionally_required.items():
+
+            condition_attribute, value = next(iter(condition.items()))
+
+            if len(condition) > 1:
+                raise NotImplementedError('Only one condition supported at the moment. ')
+
+            if not (required_attribute in existing_identifiers and condition_attribute in existing_identifiers):
+                continue
+
+            all_of.append({'oneOf': [
+                {
+                    'properties': {
+                        condition_attribute: {
+                            'enum': [value]
+                        }
+                    },
+                    'required': [required_attribute]
+                },
+                {
+                    'properties': {
+                        condition_attribute: {
+                            'not': {'enum': [value]}
+                        }
+                    },
+                    'required': []
+                },
+            ]})
+
+        if all_of:
+            schema['allOf'] = all_of
+
+    return schema

--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -29,3 +29,13 @@ def test_get(client, resource, function, phase, action, record, attribute, recor
     response = client.get(detail_url)
     assert response.status_code == 200
     assert response.data
+
+
+@pytest.mark.django_db
+def test_get_attribute_schemas(client):
+    url = '{}schemas/'.format(reverse('v1:attribute-list'))
+    response = client.get(url)
+    assert response.status_code == 200
+
+    for element in ('function', 'phase', 'action', 'record'):
+        assert len(response.data.get(element))

--- a/metarecord/tests/test_attributes.py
+++ b/metarecord/tests/test_attributes.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from metarecord.models.attribute import reload_attribute_schema
+from metarecord.models.structural_element import reload_attribute_schema
 
 
 @pytest.mark.django_db

--- a/metarecord/views/attribute.py
+++ b/metarecord/views/attribute.py
@@ -1,7 +1,9 @@
 import django_filters
 from rest_framework import serializers, viewsets
+from rest_framework.decorators import list_route
+from rest_framework.response import Response
 
-from metarecord.models import Attribute, AttributeValue
+from metarecord.models import Attribute, AttributeValue, StructuralElement
 
 
 class AttributeValueSerializer(serializers.ModelSerializer):
@@ -32,3 +34,10 @@ class AttributeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Attribute.objects.prefetch_related('values')
     serializer_class = AttributeSerializer
     filter_class = AttributeFilterSet
+
+    @list_route()
+    def schemas(self, request):
+        response = {}
+        for cls in StructuralElement.__subclasses__():
+            response[cls.__name__.lower()] = cls.get_attribute_json_schema()
+        return Response(response)

--- a/metarecord/views/base.py
+++ b/metarecord/views/base.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.decorators import list_route
 
 
 class BaseModelSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Currently an attribute schema is hardcoded for every StructuralElement
based model. Implemented a function that builds a schema in JSON schema
draft 4 format.

Includes some refactoring, moved StructuralElement model to it's own
module.

The schemas will be available from url `/attribute/schema/`, returned
structure: `{"function": <schema>, "phase": <schema> ...}`

Closes #14