### PR TITLE
Order Action, Phase and Record by index

### DIFF
--- a/metarecord/models/action.py
+++ b/metarecord/models/action.py
@@ -17,6 +17,7 @@ class Action(StructuralElement):
     class Meta:
         verbose_name = _('action')
         verbose_name_plural = _('actions')
+        ordering = ('phase', 'index')
 
     def __str__(self):
         return '%s | %s' % (self.phase, self.name)

--- a/metarecord/models/phase.py
+++ b/metarecord/models/phase.py
@@ -17,6 +17,7 @@ class Phase(StructuralElement):
     class Meta:
         verbose_name = _('phase')
         verbose_name_plural = _('phases')
+        ordering = ('function', 'index')
 
     def __str__(self):
         return '%s | %s' % (self.function, self.name)

--- a/metarecord/models/record.py
+++ b/metarecord/models/record.py
@@ -42,6 +42,7 @@ class Record(StructuralElement):
     class Meta:
         verbose_name = _('record')
         verbose_name_plural = _('records')
+        ordering = ('action', 'index')
 
     def __str__(self):
         return '%s/%s' % (self.action, self.type)


### PR DESCRIPTION
Not an ideal solution to order in the models when we actually need only to get nested resources in API ordered, but ordering just those turned out to be non-trivial (if I didn't miss something obvious). So this is probably good for now.

Closes #19