### PR TITLE
Add ability to define attributes to allow multiple values

### DIFF
--- a/metarecord/migrations/0033_change_attributes_fields_to_jsonb.py
+++ b/metarecord/migrations/0033_change_attributes_fields_to_jsonb.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django.contrib.postgres.fields.jsonb
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metarecord', '0032_add_additional_information_and_related_classification'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+        sql="""
+BEGIN;
+--
+-- Alter field attributes on action
+--
+ALTER TABLE "metarecord_action" ALTER COLUMN "attributes" TYPE jsonb USING "attributes"::jsonb, ALTER COLUMN "attributes" SET DEFAULT '{}';
+ALTER TABLE "metarecord_action" ALTER COLUMN "attributes" DROP DEFAULT;
+--
+-- Alter field attributes on function
+--
+ALTER TABLE "metarecord_function" ALTER COLUMN "attributes" TYPE jsonb USING "attributes"::jsonb, ALTER COLUMN "attributes" SET DEFAULT '{}';
+ALTER TABLE "metarecord_function" ALTER COLUMN "attributes" DROP DEFAULT;
+--
+-- Alter field attributes on phase
+--
+ALTER TABLE "metarecord_phase" ALTER COLUMN "attributes" TYPE jsonb USING "attributes"::jsonb, ALTER COLUMN "attributes" SET DEFAULT '{}';
+ALTER TABLE "metarecord_phase" ALTER COLUMN "attributes" DROP DEFAULT;
+--
+-- Alter field attributes on record
+--
+ALTER TABLE "metarecord_record" ALTER COLUMN "attributes" TYPE jsonb USING "attributes"::jsonb, ALTER COLUMN "attributes" SET DEFAULT '{}';
+ALTER TABLE "metarecord_record" ALTER COLUMN "attributes" DROP DEFAULT;
+COMMIT;""",
+        reverse_sql="""
+BEGIN;
+
+CREATE OR REPLACE FUNCTION my_jsonb_to_hstore(jsonb)
+  RETURNS hstore
+  IMMUTABLE
+  STRICT
+  LANGUAGE sql
+AS $func$
+  SELECT COALESCE(hstore(array_agg(key), array_agg(value)), hstore(array[]::varchar[]))
+  FROM jsonb_each_text($1)
+$func$;
+
+--
+-- Alter field attributes on record
+--
+ALTER TABLE "metarecord_record" ALTER COLUMN "attributes" DROP DEFAULT;
+ALTER TABLE "metarecord_record" ALTER COLUMN "attributes" TYPE hstore USING my_jsonb_to_hstore(attributes);
+--
+-- Alter field attributes on phase
+--
+ALTER TABLE "metarecord_phase" ALTER COLUMN "attributes" DROP DEFAULT;
+ALTER TABLE "metarecord_phase" ALTER COLUMN "attributes" TYPE hstore USING my_jsonb_to_hstore(attributes);
+-- 
+-- Alter field attributes on function
+--
+ALTER TABLE "metarecord_function" ALTER COLUMN "attributes" DROP DEFAULT;
+ALTER TABLE "metarecord_function" ALTER COLUMN "attributes" TYPE hstore USING my_jsonb_to_hstore(attributes);
+--
+-- Alter field attributes on action
+--
+ALTER TABLE "metarecord_action" ALTER COLUMN "attributes" DROP DEFAULT;
+ALTER TABLE "metarecord_action" ALTER COLUMN "attributes" TYPE hstore USING my_jsonb_to_hstore(attributes);
+
+DROP FUNCTION my_jsonb_to_hstore(jsonb);
+
+COMMIT;""",
+        state_operations = [
+            migrations.AlterField(
+                model_name='action',
+                name='attributes',
+                field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, verbose_name='attributes'),
+            ),
+            migrations.AlterField(
+                model_name='function',
+                name='attributes',
+                field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, verbose_name='attributes'),
+            ),
+            migrations.AlterField(
+                model_name='phase',
+                name='attributes',
+                field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, verbose_name='attributes'),
+            ),
+            migrations.AlterField(
+                model_name='record',
+                name='attributes',
+                field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, verbose_name='attributes'),
+            ),
+        ])
+    ]

--- a/metarecord/models/action.py
+++ b/metarecord/models/action.py
@@ -12,6 +12,9 @@ class Action(StructuralElement):
     _attribute_validations = {
         'allowed': (
             'ActionType', 'AdditionalInformation', 'InformationSystem', 'ProcessStatus', 'TypeSpecifier'
+        ),
+        'multivalued': (
+            'InformationSystem',
         )
     }
 

--- a/metarecord/models/function.py
+++ b/metarecord/models/function.py
@@ -58,7 +58,11 @@ class Function(StructuralElement):
             'SecurityPeriod': {'PublicityClass': ('Salassa pidettävä', 'Osittain salassa pidettävä')},
             'Restriction.SecurityPeriodStart': {'PublicityClass': ('Salassa pidettävä', 'Osittain salassa pidettävä')},
             'SecurityReason': {'PublicityClass': ('Salassa pidettävä', 'Osittain salassa pidettävä')}
-        }
+        },
+        'multivalued': (
+            'CollectiveProcessIDSource', 'DataGroup', 'InformationSystem', 'ProcessOwner', 'RetentionReason',
+            'SecurityReason', 'Subject', 'Subject.Scheme',
+        )
     }
 
     class Meta:

--- a/metarecord/models/phase.py
+++ b/metarecord/models/phase.py
@@ -12,7 +12,11 @@ class Phase(StructuralElement):
     _attribute_validations = {
         'allowed': (
             'AdditionalInformation', 'InformationSystem', 'PhaseType', 'ProcessStatus', 'TypeSpecifier'
+        ),
+        'multivalued': (
+            'InformationSystem',
         )
+
     }
 
     class Meta:

--- a/metarecord/models/record.py
+++ b/metarecord/models/record.py
@@ -25,7 +25,10 @@ class Record(StructuralElement):
             'SecurityPeriod': {'PublicityClass': ('Salassa pidettävä', 'Osittain salassa pidettävä')},
             'Restriction.SecurityPeriodStart': {'PublicityClass': ('Salassa pidettävä', 'Osittain salassa pidettävä')},
             'SecurityReason': {'PublicityClass': ('Salassa pidettävä', 'Osittain salassa pidettävä')}
-        }
+        },
+        'multivalued': (
+            'DataGroup', 'InformationSystem', 'RetentionReason', 'SecurityReason', 'Subject', 'Subject.Scheme',
+        )
     }
 
     class Meta:


### PR DESCRIPTION
Attributes database field had to be changed from HStore to JSON because
HStore allows only strings as values. Attribute validation is modified
to check that only attributes allowing multiple values can contain
list as a value.