### PR TITLE
Bugfix: add missing keys to allowed keys in Record

### DIFF
--- a/metarecord/models/record.py
+++ b/metarecord/models/record.py
@@ -14,9 +14,10 @@ class Record(StructuralElement):
         'allowed': (
             'AdditionalInformation', 'DataGroup', 'DisposePreviousVersions', 'InformationSystem', 'PersonalData',
             'PublicityClass', 'PublicityClassChange', 'RecordType', 'Restriction.ProtectionLevel',
-            'Restriction.SecurityClass', 'RetentionPeriod', 'RetentionPeriodStart', 'RetentionPeriodTotal',
-            'RetentionPeriodOffice', 'RetentionReason', 'ProtectionClass', 'SecurityPeriod', 'SocialSecurityNumber',
-            'StorageAccountable', 'StorageOrder', 'Subject.Scheme', 'Subject', 'TypeSpecifier'
+            'Restriction.SecurityClass', 'Restriction.SecurityPeriodStart', 'RetentionPeriod', 'RetentionPeriodStart',
+            'RetentionPeriodTotal', 'RetentionPeriodOffice', 'RetentionReason', 'ProtectionClass', 'SecurityPeriod',
+            'SecurityReason', 'SocialSecurityNumber', 'StorageAccountable', 'StorageOrder', 'Subject.Scheme', 'Subject',
+            'TypeSpecifier'
         ),
         'required': (
             'PersonalData', 'PublicityClass', 'RecordType', 'RetentionPeriod', 'RetentionPeriodStart', 'RetentionReason'

--- a/metarecord/tests/test_attribute_validations.py
+++ b/metarecord/tests/test_attribute_validations.py
@@ -1,0 +1,12 @@
+import pytest
+from metarecord.models import Action, Function, Phase, Record
+
+
+@pytest.mark.parametrize('model', [Action, Function, Phase, Record])
+def test_allowed_contains_required_keys(model):
+    required_keys = set(model._attribute_validations.get('required', {})) | set(
+        model._attribute_validations.get('conditionally_required', {}).keys())
+
+    assert set(model._attribute_validations['allowed']).issuperset(required_keys), \
+        'allowedKeys does not contain all the required keys in the model "{}" attribute validations'.format(
+            model.__name__)


### PR DESCRIPTION
Also added a test which validates that all the keys in the required or conditionally_required attributes are in the allowed set.

Closes #129 