### PR TITLE
Disallow function creation

### DIFF
--- a/metarecord/models/classification.py
+++ b/metarecord/models/classification.py
@@ -22,3 +22,7 @@ class Classification(TimeStampedModel):
 
     def __str__(self):
         return self.code
+
+    # only applies to API
+    def function_allowed(self):
+        return not self.children.exists()

--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1047,7 +1047,18 @@ def test_function_patch_required_fields(put_function_data, user_api_client, func
 
 
 @pytest.mark.django_db
-def test_function_validation_date_validation(user_api_client, function, put_function_data):
+def test_function_validation_date_validation_on_create(user_api_client, post_function_data):
+    set_permissions(user_api_client, Function.CAN_EDIT)
+    post_function_data['valid_from'] = '2015-01-02'
+    post_function_data['valid_to'] = '2015-01-01'
+
+    response = user_api_client.post(FUNCTION_LIST_URL, data=post_function_data)
+    assert response.status_code == 400
+    assert '"valid_from" cannot be after "valid_to".' in str(response.data)
+
+
+@pytest.mark.django_db
+def test_function_validation_date_validation_on_edit(user_api_client, function, put_function_data):
     url = get_function_detail_url(function)
     set_permissions(user_api_client, (Function.CAN_EDIT, Function.CAN_REVIEW))
     put_function_data['valid_from'] = '2015-01-02'

--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1419,3 +1419,75 @@ def test_function_visibility_in_version_history(api_client, user_api_client, cla
         assert version_history_states == [Function.APPROVED, Function.APPROVED]
         assert version_history[0]['version'] == 4
         assert version_history[1]['version'] == 6
+
+
+@pytest.mark.parametrize('endpoint', ('list', 'detail'))
+@pytest.mark.django_db
+def test_classification_allow_function_field(user_api_client, classification, endpoint):
+    url = CLASSIFICATION_LIST_URL if endpoint == 'list' else get_classification_detail_url(classification)
+
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+    result = response.data['results'][0] if endpoint == 'list' else response.data
+
+    assert result['function_allowed'] == True
+
+    classification_2 = Classification.objects.create(parent=classification, code='00 01')
+
+    if endpoint == 'list':
+        response = user_api_client.get(CLASSIFICATION_LIST_URL)
+        assert response.status_code == 200
+        parent_result = response.data['results'][0]
+        child_result = response.data['results'][1]
+    else:
+        response = user_api_client.get(get_classification_detail_url(classification))
+        assert response.status_code == 200
+        parent_result = response.data
+        response = user_api_client.get(get_classification_detail_url(classification_2))
+        assert response.status_code == 200
+        child_result = response.data
+
+    assert parent_result['function_allowed'] == False
+    assert child_result['function_allowed'] == True
+
+
+@pytest.mark.parametrize('endpoint', ('list', 'detail'))
+@pytest.mark.django_db
+def test_classification_allow_function_field(user_api_client, classification, endpoint):
+    url = CLASSIFICATION_LIST_URL if endpoint == 'list' else get_classification_detail_url(classification)
+
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+    result = response.data['results'][0] if endpoint == 'list' else response.data
+
+    assert result['function_allowed'] == True
+
+    classification_2 = Classification.objects.create(parent=classification, code='00 01')
+
+    if endpoint == 'list':
+        response = user_api_client.get(CLASSIFICATION_LIST_URL)
+        assert response.status_code == 200
+        parent_result = response.data['results'][0]
+        child_result = response.data['results'][1]
+    else:
+        response = user_api_client.get(get_classification_detail_url(classification))
+        assert response.status_code == 200
+        parent_result = response.data
+        response = user_api_client.get(get_classification_detail_url(classification_2))
+        assert response.status_code == 200
+        child_result = response.data
+
+    assert parent_result['function_allowed'] == False
+    assert child_result['function_allowed'] == True
+
+
+@pytest.mark.django_db
+def test_function_post_when_not_allowed(post_function_data, user_api_client):
+    set_permissions(user_api_client, Function.CAN_EDIT)
+    parent_classification = Classification.objects.get(uuid=post_function_data['classification'])
+    Classification.objects.create(parent=parent_classification, code='00 01')
+
+    response = user_api_client.post(FUNCTION_LIST_URL, data=post_function_data)
+    assert response.status_code == 400
+    expected_error = 'Classification %s does not allow function creation.' % parent_classification.uuid
+    assert expected_error in response.data['non_field_errors']

--- a/metarecord/views/classification.py
+++ b/metarecord/views/classification.py
@@ -8,11 +8,12 @@ from .base import HexRelatedField
 class ClassificationSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(source='uuid', format='hex', read_only=True)
     parent = HexRelatedField(read_only=True)
+    function_allowed = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = Classification
         fields = ('id', 'created_at', 'modified_at', 'code', 'title', 'parent', 'description', 'description_internal',
-                  'related_classification', 'additional_information')
+                  'related_classification', 'additional_information', 'function_allowed')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/metarecord/views/function.py
+++ b/metarecord/views/function.py
@@ -110,6 +110,10 @@ class FunctionListSerializer(StructuralElementSerializer):
             raise exceptions.ValidationError(
                 _('Classification %s already has a function.') % data['classification'].uuid
             )
+        if not data['classification'].function_allowed():
+            raise exceptions.ValidationError(
+                _('Classification %s does not allow function creation.') % data['classification'].uuid
+            )
         return data
 
     @transaction.atomic


### PR DESCRIPTION
Disallowed function creation for other than leaf classifications and added `function_allowed` field to classification API data.

Also fixed a couple of unrelated bugs that were stumbled upon.

Closes #160 