### PR TITLE
Make classification CSV-importer more robust

### DIFF
--- a/metarecord/importer/classification.py
+++ b/metarecord/importer/classification.py
@@ -11,11 +11,11 @@ def clean_row(row):
 
 class ClassificationImporter:
     def __init__(self, filename):
-        with open(filename, 'r', encoding='utf8') as csvfile:
+        with open(filename, 'r', encoding='utf8', newline='') as csvfile:
             sniffer = csv.Sniffer()
             sniffer.preferred = [',', ';', '\t']
 
-            dialect = sniffer.sniff(csvfile.readline())
+            dialect = sniffer.sniff(csvfile.read())
             csvfile.seek(0)
 
             self.csv_data = list(csv.reader(csvfile, dialect=dialect))

--- a/metarecord/importer/classification.py
+++ b/metarecord/importer/classification.py
@@ -17,12 +17,11 @@ class ClassificationImporter:
 
             dialect = sniffer.sniff(csvfile.read())
             # Sniffer gets this wrong for our data
-            dialect.doublequote=True
+            dialect.doublequote = True
             csvfile.seek(0)
 
             self.csv_data = list(csv.reader(csvfile, dialect=dialect))
-            import pprint
-            pprint.pprint(self.csv_data)
+
     def _get_parent_code(self, code):
         if len(code) == 2:
             return None
@@ -39,6 +38,7 @@ class ClassificationImporter:
             count += 1
             if len(row) < 2 or not re.match(r"^\d\d(?:\s\d\d)*$", row[0]):
                 print('Skipping row number {}'.format(count))
+                print('Newline cleaned content was:\n{}'.format(row))
                 continue
 
             code = row[0]

--- a/metarecord/importer/classification.py
+++ b/metarecord/importer/classification.py
@@ -16,10 +16,13 @@ class ClassificationImporter:
             sniffer.preferred = [',', ';', '\t']
 
             dialect = sniffer.sniff(csvfile.read())
+            # Sniffer gets this wrong for our data
+            dialect.doublequote=True
             csvfile.seek(0)
 
             self.csv_data = list(csv.reader(csvfile, dialect=dialect))
-
+            import pprint
+            pprint.pprint(self.csv_data)
     def _get_parent_code(self, code):
         if len(code) == 2:
             return None


### PR DESCRIPTION
Open the csv file with newline='' as per https://docs.python.org/3/library/csv.html#csv.reader

Also read the whole file for format sniffing. This can be done as classification sheets are relatively short. Even with this, the "doubled doublequotes"-style of string handling must be forced.

Thirdly, output any date rows deemed to be invalid. Makes for easier debugging.