### PR TITLE
Add phases to classification endpoint

### DIFF
--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1257,6 +1257,25 @@ def test_classification_function_field(user_api_client, classification, classifi
 
 
 @pytest.mark.django_db
+def test_classification_phase_field(user_api_client, classification, classification_2):
+    function = Function.objects.create(classification=classification)
+    function_2 = Function.objects.create(classification=classification_2)
+    phase = Phase.objects.create(function=function)
+    phase_2 = Phase.objects.create(function=function)
+
+    response = user_api_client.get(get_classification_detail_url(classification))
+    assert response.status_code == 200
+    assert response.data['function'] == function.uuid.hex
+    assert response.data['phases'][0]['id'] == phase.uuid.hex
+    assert response.data['phases'][1]['id'] == phase_2.uuid.hex
+
+    response = user_api_client.get(get_classification_detail_url(classification_2))
+    assert response.status_code == 200
+    assert response.data['function'] == function_2.uuid.hex
+    assert response.data['phases'] == []
+
+
+@pytest.mark.django_db
 def test_function_version_history_field(user_api_client, classification, user_2):
     functions = (
         Function.objects.create(classification=classification, modified_by=None),

--- a/metarecord/views/classification.py
+++ b/metarecord/views/classification.py
@@ -78,7 +78,13 @@ class ClassificationViewSet(viewsets.ReadOnlyModelViewSet):
 
         return super().get_queryset().prefetch_related(
             Prefetch(
-                'functions', queryset=Function.objects.filter_for_user(user).latest_version(),
+                'functions',
+                queryset=(
+                    Function.objects
+                    .filter_for_user(user)
+                    .latest_version()
+                    .prefetch_related('phases', 'phases__actions', 'phases__actions__records')
+                ),
                 to_attr='prefetched_functions'
             )
         )


### PR DESCRIPTION
Add phases that are related to the function that is related
to the classification in the classification API endpoint.

Resolves #207 