### PR TITLE
Revert PR 205

### DIFF
--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1532,13 +1532,10 @@ def test_function_visibility_in_version_history(api_client, user_api_client, cla
             Function.SENT_FOR_REVIEW,
             Function.WAITING_FOR_APPROVAL,
         ]
-        assert version_history[0]['version'] == 1
-        assert version_history[1]['version'] == 3
-        assert version_history[4]['version'] == 6
     else:
         assert version_history_states == [Function.APPROVED, Function.APPROVED]
-        assert 'version' not in version_history[0]
-        assert 'version' not in version_history[1]
+        assert version_history[0]['version'] == 1
+        assert version_history[1]['version'] == 3
 
 
 @pytest.mark.django_db

--- a/metarecord/views/base.py
+++ b/metarecord/views/base.py
@@ -26,15 +26,12 @@ class StructuralElementSerializer(serializers.ModelSerializer):
         if 'request' not in self._context:
             return fields
 
-        request = self._context['request']
+        request = self._context["request"]
 
-        # Hide modified_by if user doesn't have necessary permissions
-        if 'modified_by' in fields and not StructuralElement.can_view_modified_by(request.user):
-            fields.pop('modified_by')
-
-        # Hide version number from unauthenticated users.
-        if 'version' in fields and not request.user.is_authenticated:
-            fields.pop('version')
+        fields = {
+            field_name: field for field_name, field in fields.items()
+            if field_name != 'modified_by' or StructuralElement.can_view_modified_by(request.user)
+        }
 
         return fields
 

--- a/metarecord/views/function.py
+++ b/metarecord/views/function.py
@@ -239,13 +239,10 @@ class FunctionDetailSerializer(FunctionListSerializer):
         ret = []
 
         for function in functions:
-            version_data = {attr: getattr(function, attr) for attr in ('state', 'modified_at')}
+            version_data = {attr: getattr(function, attr) for attr in ('state', 'version', 'modified_at')}
 
             if not request or function.can_view_modified_by(request.user):
                 version_data['modified_by'] = function.get_modified_by_display()
-
-            if request and request.user.is_authenticated:
-                version_data['version'] = function.version
 
             ret.append(version_data)
 


### PR DESCRIPTION
The version number will be hidden from UI. UI uses the version numbers for other functionality and removing them causes other issues.

Closes #212 