### PR TITLE
Cache JHS 191 XML export

### DIFF
--- a/helerm/urls.py
+++ b/helerm/urls.py
@@ -3,6 +3,7 @@ from helusers import admin
 from rest_framework.routers import DefaultRouter
 
 from metarecord.views import AttributeViewSet, ClassificationViewSet, ExportView, FunctionViewSet, TemplateViewSet
+from metarecord.views.export import JHSExportViewSet
 from users.views import UserViewSet
 
 router = DefaultRouter()
@@ -11,6 +12,7 @@ router.register(r'attribute', AttributeViewSet)
 router.register(r'template', TemplateViewSet, base_name='template')
 router.register(r'user', UserViewSet)
 router.register(r'classification', ClassificationViewSet)
+router.register(r'export/jhs191', JHSExportViewSet, base_name='jhs191_export')
 
 urlpatterns = [
     path('v1/', include(router.urls)),

--- a/metarecord/management/commands/update_saved_jhs_file.py
+++ b/metarecord/management/commands/update_saved_jhs_file.py
@@ -1,0 +1,11 @@
+from django.core.management import BaseCommand
+
+from metarecord.views.export import create_saved_jhs_xml
+
+
+class Command(BaseCommand):
+
+    help = "Update new version of JHS191 XML to saved file used as a cache."
+
+    def handle(self, *args, **options):
+        create_saved_jhs_xml()

--- a/metarecord/views/export.py
+++ b/metarecord/views/export.py
@@ -1,14 +1,45 @@
 import logging
+import os
 
+from django.conf import settings
 from django.http import HttpResponse
 from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
+from rest_framework.viewsets import ViewSet
 
 from metarecord.exporter.jhs import JHSExporter, JHSExporterException
 from metarecord.models import Function
 from metarecord.views.function import FunctionFilterSet
 
 logger = logging.getLogger(__name__)
+
+
+def create_saved_jhs_xml():
+    try:
+        exporter = JHSExporter(output=True)
+        xml = exporter.create_xml()
+        save_jhs_export_to_file(xml)
+
+        return xml
+
+    except JHSExporterException as e:
+        logger.error('Exception while creating a cached JHS191 XML export: %s' % e)
+        raise APIException('Could not create an XML export.')
+
+
+def save_jhs_export_to_file(xml):
+
+    directory = os.path.join(settings.MEDIA_ROOT, "export")
+
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    file_path = os.path.join(directory, 'helerm-jhs191-export.xml')
+
+    with open(file_path, "wb") as f:
+        f.write(xml)
+
+    return file_path
 
 
 class ExportView(APIView):
@@ -30,5 +61,25 @@ class ExportView(APIView):
 
         response = HttpResponse(xml, content_type='application/xml')
         response['Content-Disposition'] = 'attachment; filename="helerm-export.xml"'
+
+        return response
+
+
+class JHSExportViewSet(ViewSet):
+
+    def list(self, request, format=None):
+
+        export_file_path = os.path.join(settings.MEDIA_ROOT + '/export/helerm-jhs191-export.xml')
+
+        try:
+            xml = open(export_file_path)
+        except FileNotFoundError:
+            xml = None
+
+        if not xml:
+            xml = create_saved_jhs_xml()
+
+        response = HttpResponse(xml, content_type='application/xml')
+        response['Content-Disposition'] = 'attachment; filename="helerm-jhs191-export.xml"'
 
         return response


### PR DESCRIPTION
Create a new endpoint for “cached” JHS XML export file (the generated xml is saved as a file instead of using Django’s cache.)
The file should be updated every 6 hours in specific times, so create a command for that task.

The endpoint for this cached version of export should be listed in api root and therefore the view is ViewSet type.

Refs #202