### PR TITLE
Update to Python 3.6 and Postgres 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,30 @@
-language: python
-
-python:
-- '3.6'
-addons:
-  postgresql: "9.5"
-
+dist: xenial
 sudo: false
-
+language: python
+python: '3.6'
+services:
+  - postgresql
 cache:
   directories:
   - $HOME/.cache/pip
-before_cache:
-- rm -f $HOME/.cache/pip/log/debug.log
 
-install:
-- pip install --upgrade pip
-- pip install coveralls -r requirements.txt -r dev-requirements.txt
+addons:
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
 
 before_script:
   - psql template1 -c 'create extension hstore;'
-
+install:
+- pip install --upgrade pip
+- pip install coveralls -r requirements.txt -r dev-requirements.txt
 script:
   - flake8
   - pytest -ra -vvv
+before_cache:
+- rm -f $HOME/.cache/pip/log/debug.log
 
 notifications:
   slack:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM python:3.4-stretch
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 
-RUN mkdir /code
-WORKDIR /code
+# Allows installation of postgresql-client-10 on Debian stretch which the Python images are based on
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list
+RUN wget -q -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update && apt-get install -y \
     gettext \
-    postgresql-client-9.6
+    postgresql-client-10
+
+RUN pip install -U pip
+
+RUN mkdir /code
+WORKDIR /code
 
 ADD requirements.txt /code/
 ADD dev-requirements.txt /code/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- Python 3.4+
-- PostgreSQL 9.1+
+- Python 3.6
+- PostgreSQL 10.6
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:9.6
+    image: postgres:10.6
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
@@ -9,8 +9,8 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - helerm_postgres96-data-volume:/var/lib/postgresql/data
-    container_name: helerm_postgres96
+      - helerm_postgres-data-volume:/var/lib/postgresql/data
+    container_name: helerm_postgres
 
   django:
     build: .
@@ -24,4 +24,4 @@ services:
     container_name: helerm
 
 volumes:
-  helerm_postgres96-data-volume:
+  helerm_postgres-data-volume:


### PR DESCRIPTION
Use Python 3.6 and Postgres 10 in Docker Compose development
environment. Use Postgres 10 in Travis as well. Python 3.6 is
already being used in Travis.

These versions are closer to what's easily available in Ubuntu 18.04
package repository.