### PR TITLE
Allow bulk update of function valid_from and valid_to dates

### DIFF
--- a/metarecord/models/bulk_update.py
+++ b/metarecord/models/bulk_update.py
@@ -97,7 +97,7 @@ class BulkUpdate(TimeStampedModel, UUIDPrimaryKeyModel):
             function = create_new_function_version(base_function, user)
             function.bulk_update = self
             function.state = self.state
-            self._apply_changes_to_instance(function, function_updates, fields=('attributes',))
+            self._apply_changes_to_instance(function, function_updates, fields=('attributes', 'valid_from', 'valid_to'))
             function.save()
 
             for phase_uuid, phase_updates in phases.items():


### PR DESCRIPTION
Add valid_from and valid_to to allowed bulk update fields on function
level. Add unit test for bulk updating these fields.

Fixes #224