### PR TITLE
List bulk update permissions in user API permission list

### DIFF
--- a/metarecord/tests/test_user.py
+++ b/metarecord/tests/test_user.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -70,3 +72,16 @@ def test_user_detail_endpoint(user, user_2, user_api_client):
 def test_cannot_see_other_user_data(user, user_2, user_api_client):
     response = user_api_client.get(get_detail_url(user_2))
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_user_permission_list(user, user_api_client):
+    permissions = Permission.objects.filter(codename__in=(
+        'can_view_modified_by', 'add_bulkupdate', 'approve_bulkupdate'))
+    user.user_permissions.add(*permissions)
+
+    response = user_api_client.get(get_detail_url(user))
+    response_data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert response_data['permissions'] == ['can_view_modified_by', 'add_bulkupdate', 'approve_bulkupdate']

--- a/users/views.py
+++ b/users/views.py
@@ -1,7 +1,10 @@
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from rest_framework import permissions, serializers, viewsets
 
 from metarecord.models import Function
+from metarecord.models.bulk_update import BulkUpdate
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -11,9 +14,27 @@ class UserSerializer(serializers.ModelSerializer):
         model = get_user_model()
         fields = ('uuid', 'username', 'first_name', 'last_name', 'permissions')
 
-    def get_permissions(self, obj):
+    def _get_user_bulk_update_permissions(self, user):
+        content_type = ContentType.objects.get_for_model(BulkUpdate)
+        permissions = Permission.objects.filter(content_type=content_type)
+        return [
+            perm.codename
+            for perm in permissions
+            if user.has_perm('%s.%s' % (content_type.app_label, perm.codename))
+        ]
+
+    def _get_user_function_permissions(self, user):
         app_label = Function._meta.app_label
-        return [perm[0] for perm in Function._meta.permissions if obj.has_perm('%s.%s' % (app_label, perm[0]))]
+        return [
+            perm[0]
+            for perm in Function._meta.permissions
+            if user.has_perm('%s.%s' % (app_label, perm[0]))
+        ]
+
+    def get_permissions(self, obj):
+        function_permissions = self._get_user_function_permissions(obj)
+        bulk_update_permissions = self._get_user_bulk_update_permissions(obj)
+        return function_permissions + bulk_update_permissions
 
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Add user bulk update permissions to user API endpoint permission list.
These permissions are used by the client app to hide/show things to
users depending what users have permission to do.

Resolves #234