### PR TITLE
Update urllib3 to 1.24.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,4 @@ pyxb==1.2.6
 requests-oauthlib==1.0.0  # via django-allauth
 requests==2.21.0          # via django-allauth, django-helusers, pyjwkest, requests-oauthlib
 six==1.11.0               # via more-itertools, pip-tools, pyjwkest, pytest
-urllib3==1.23             # via requests
+urllib3==1.24.3           # via requests


### PR DESCRIPTION
Urllib3 1.24.2 and older have CRLF injection vulnerability.
https://www.cvedetails.com/cve/CVE-2019-11236/

Resolves #236