### PR TITLE
Return 401 when requesting function without authentication

### DIFF
--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1484,7 +1484,7 @@ def test_function_visibility(api_client, user_api_client, classification, authen
         assert response.status_code == 200
         assert response.data['state'] == Function.WAITING_FOR_APPROVAL
     else:
-        assert response.status_code == 404
+        assert response.status_code == 401
 
     Function.objects.create(classification=classification, state=Function.APPROVED)
     Function.objects.create(classification=classification, state=Function.DRAFT)
@@ -1571,7 +1571,7 @@ def test_function_version_filter(api_client, user_api_client, classification, au
         assert response.status_code == 200
         assert response.data['state'] == function.state
     else:
-        assert response.status_code == 404
+        assert response.status_code == 401
 
 
 @pytest.mark.django_db

--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1462,6 +1462,19 @@ def test_function_not_exist(api_client, user_api_client, authenticated):
 
 @pytest.mark.parametrize('authenticated', (False, True))
 @pytest.mark.django_db
+def test_function_invalid_uuid(api_client, user_api_client, authenticated):
+    client = user_api_client if authenticated else api_client
+
+    mock_function = mock.Mock(spec=Function)
+    mock_function.uuid = "does-not-exist"
+
+    response = client.get(get_function_detail_url(mock_function))
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize('authenticated', (False, True))
+@pytest.mark.django_db
 def test_function_visibility_in_list(api_client, user_api_client, classification, classification_2, authenticated):
     client = user_api_client if authenticated else api_client
 

--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import uuid
+from unittest import mock
 
 import freezegun
 import pytest
@@ -1444,6 +1445,19 @@ def test_classification_function_validity_date_fields(user_api_client, classific
     assert response.status_code == 200
     assert not response.data['function_valid_from']
     assert not response.data['function_valid_to']
+
+
+@pytest.mark.parametrize('authenticated', (False, True))
+@pytest.mark.django_db
+def test_function_not_exist(api_client, user_api_client, authenticated):
+    client = user_api_client if authenticated else api_client
+
+    mock_function = mock.Mock(spec=Function)
+    mock_function.uuid = "41418bd7-8cf8-443c-9bdf-8837bde2e73a"
+
+    response = client.get(get_function_detail_url(mock_function))
+
+    assert response.status_code == 404
 
 
 @pytest.mark.parametrize('authenticated', (False, True))

--- a/metarecord/utils.py
+++ b/metarecord/utils.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from uuid import UUID
 
 from metarecord.models import Function, Phase, Action, Record
 
@@ -74,3 +75,12 @@ def update_nested_dictionary(old, new):
             old[key] = new_value
 
     return old
+
+
+def validate_uuid4(string):
+    try:
+        UUID(string, version=4)
+    except (AttributeError, ValueError, TypeError):
+        return False
+    else:
+        return True


### PR DESCRIPTION
Problem is that end-users are linking function by copy&pasting url from
the system to each other. When user is not logged in and opened
function that is not approved the system gave 404. This is causing
confusion between users. We decided to change the error code to 401,
this way UI can ask user to log in or redirect to login page.

Implemented extra checks when retrieving function. These check decide
what code to return. In short return 401 is function is found, but user
can not view it. Due to few corner cases there was need to create few
extra checks. When request includes version and function is not found
return 404.

Resolves #245 