### PR TITLE
Update Django to 2.2.9

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 pip-tools
-Django~=2.2.8
+Django~=2.2.0
 django-helusers
 pytz
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-allauth==0.39.1
 django-cors-headers==2.5.3
 django-filter==2.1.0
 django-helusers==0.4.5
-django==2.2.8
+django==2.2.9
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.9.4


### PR DESCRIPTION
Update to Django 2.2.9 to address CVE-2019-19844 that potentially
allows account hijacking via password reset form.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19844