### PR TITLE
Optionally enable create_saved_jhs_xml output

### DIFF
--- a/metarecord/management/commands/update_saved_jhs_file.py
+++ b/metarecord/management/commands/update_saved_jhs_file.py
@@ -7,5 +7,12 @@ class Command(BaseCommand):
 
     help = "Update new version of JHS191 XML to saved file used as a cache."
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            action="store_true",
+            help="Print output to terminal",
+        )
+
     def handle(self, *args, **options):
-        create_saved_jhs_xml()
+        create_saved_jhs_xml(output=options["output"])

--- a/metarecord/views/export.py
+++ b/metarecord/views/export.py
@@ -14,9 +14,9 @@ from metarecord.views.function import FunctionFilterSet
 logger = logging.getLogger(__name__)
 
 
-def create_saved_jhs_xml():
+def create_saved_jhs_xml(output=False):
     try:
-        exporter = JHSExporter(output=False)
+        exporter = JHSExporter(output=output)
         xml = exporter.create_xml()
         save_jhs_export_to_file(xml)
 


### PR DESCRIPTION
Add a `--output` flag to `create_saved_jhs_xml` management command to
optionally enable the output when generating the export XML. This should
be helpful when debugging the exporter in test or production
environments.