### PR TITLE
JHS191 export improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov
 .cache
 .DS_Store
 .pytest_cache/
+export/

--- a/data/Skeema_TOS_atomaariset_HKI_custom.xsd
+++ b/data/Skeema_TOS_atomaariset_HKI_custom.xsd
@@ -222,6 +222,16 @@ xx.04.2014: palautekierrosten perusteella muokattu versio
 					<xs:documentation>Sisältää arkaluonteisia henkilötietoja</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Sisältää erityisiä henkilötietoja</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Sisältää rikoksiin tai rikkomuksiin liittyvää henkilötietoa</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 

--- a/data/Skeema_TOS_kooste_HKI_custom.xsd
+++ b/data/Skeema_TOS_kooste_HKI_custom.xsd
@@ -120,7 +120,7 @@ xx.04.2014: palautekierrosten perusteella muokattu versio
 			<xs:element ref="tos:TietojarjestelmaNimi" minOccurs="0"/>
 			<xs:element ref="tos:Kayttorajoitustiedot"/>
 			<xs:element ref="tos:Sailytysaikatiedot"/>
-			<xs:element ref="tos:Toimenpidetiedot" maxOccurs="unbounded"/>
+			<xs:element ref="tos:Toimenpidetiedot" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="tos:OrganisaatioNimi" minOccurs="0"/>
 			<xs:element ref="tos:LaatijaNimi" minOccurs="0"/>
 			<xs:element ref="tos:LaadittuPvm" minOccurs="0"/>

--- a/metarecord/binding/_jhs.py
+++ b/metarecord/binding/_jhs.py
@@ -1,7 +1,7 @@
 # ./metarecord/binding/_jhs.py
 # -*- coding: utf-8 -*-
 # PyXB bindings for NM:567ab21ac37a6d7db45f717b194c27c1e22858bd
-# Generated 2020-04-02 13:07:27.743349 by PyXB version 1.2.6 using Python 3.6.10.final.0
+# Generated 2020-04-06 06:44:21.528876 by PyXB version 1.2.6 using Python 3.6.10.final.0
 # Namespace http://skeemat.jhs-suositukset.fi/yhteiset/2009/10/19 [xmlns:jhs]
 
 from __future__ import unicode_literals
@@ -14,7 +14,7 @@ import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:e7074e5c-74e2-11ea-80ec-0242ac1e0003')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0bd4d60e-77d2-11ea-a270-0242c0a80003')
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = '1.2.6'

--- a/metarecord/binding/_jhs.py
+++ b/metarecord/binding/_jhs.py
@@ -1,7 +1,7 @@
 # ./metarecord/binding/_jhs.py
 # -*- coding: utf-8 -*-
 # PyXB bindings for NM:567ab21ac37a6d7db45f717b194c27c1e22858bd
-# Generated 2019-12-11 14:34:21.681636 by PyXB version 1.2.6 using Python 3.6.8.final.0
+# Generated 2020-04-02 13:07:27.743349 by PyXB version 1.2.6 using Python 3.6.10.final.0
 # Namespace http://skeemat.jhs-suositukset.fi/yhteiset/2009/10/19 [xmlns:jhs]
 
 from __future__ import unicode_literals
@@ -14,7 +14,7 @@ import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:521cb998-1c23-11ea-8e24-0242ac180003')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:e7074e5c-74e2-11ea-80ec-0242ac1e0003')
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = '1.2.6'

--- a/metarecord/binding/jhs.py
+++ b/metarecord/binding/jhs.py
@@ -1,7 +1,7 @@
 # ./metarecord/binding/jhs.py
 # -*- coding: utf-8 -*-
 # PyXB bindings for NM:0bcf4fe07fa483312851437fc9b3f33582a4d3fa
-# Generated 2019-12-11 14:34:21.681909 by PyXB version 1.2.6 using Python 3.6.8.final.0
+# Generated 2020-04-02 13:07:27.746666 by PyXB version 1.2.6 using Python 3.6.10.final.0
 # Namespace http://skeemat.jhs-suositukset.fi/tos/2015/01/15
 
 from __future__ import unicode_literals
@@ -14,7 +14,7 @@ import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:521cb998-1c23-11ea-8e24-0242ac180003')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:e7074e5c-74e2-11ea-80ec-0242ac1e0003')
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = '1.2.6'
@@ -2958,7 +2958,7 @@ def _BuildAutomaton_10 ():
     counters = set()
     cc_0 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=None)
+    cc_1 = fac.CounterCondition(min=0, max=None, metadata=None)
     counters.add(cc_1)
     cc_2 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_2)
@@ -2976,16 +2976,18 @@ def _BuildAutomaton_10 ():
     counters.add(cc_8)
     cc_9 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_9)
-    cc_10 = fac.CounterCondition(min=0, max=None, metadata=None)
+    cc_10 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_10)
-    cc_11 = fac.CounterCondition(min=0, max=1, metadata=None)
+    cc_11 = fac.CounterCondition(min=0, max=None, metadata=None)
     counters.add(cc_11)
     cc_12 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_12)
     cc_13 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_13)
-    cc_14 = fac.CounterCondition(min=0, max=None, metadata=None)
+    cc_14 = fac.CounterCondition(min=0, max=1, metadata=None)
     counters.add(cc_14)
+    cc_15 = fac.CounterCondition(min=0, max=None, metadata=None)
+    counters.add(cc_15)
     states = []
     final_update = None
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'TietojarjestelmaNimi')), None)
@@ -2995,81 +2997,82 @@ def _BuildAutomaton_10 ():
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Kayttorajoitustiedot')), None)
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
-    final_update = None
+    final_update = set()
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Sailytysaikatiedot')), None)
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
+    final_update.add(fac.UpdateInstruction(cc_1, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Toimenpidetiedot')), None)
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_1, False))
+    final_update.add(fac.UpdateInstruction(cc_2, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OrganisaatioNimi')), None)
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_2, False))
+    final_update.add(fac.UpdateInstruction(cc_3, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'LaatijaNimi')), None)
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_3, False))
+    final_update.add(fac.UpdateInstruction(cc_4, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'LaadittuPvm')), None)
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_4, False))
+    final_update.add(fac.UpdateInstruction(cc_5, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MuokkaajaNimi')), None)
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_5, False))
+    final_update.add(fac.UpdateInstruction(cc_6, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MuokattuPvm')), None)
     st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_8)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_6, False))
+    final_update.add(fac.UpdateInstruction(cc_7, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'HyvaksyjaNimi')), None)
     st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_9)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_7, False))
+    final_update.add(fac.UpdateInstruction(cc_8, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'HyvaksyttyPvm')), None)
     st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_10)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_8, False))
+    final_update.add(fac.UpdateInstruction(cc_9, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'VoimassaoloAlkaaPvm')), None)
     st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_11)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_9, False))
+    final_update.add(fac.UpdateInstruction(cc_10, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'VoimassaoloPaattyyPvm')), None)
     st_12 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_12)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_10, False))
+    final_update.add(fac.UpdateInstruction(cc_11, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Asiasanat')), None)
     st_13 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_13)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_11, False))
+    final_update.add(fac.UpdateInstruction(cc_12, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PaatietoryhmatTeksti')), None)
     st_14 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_14)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_12, False))
+    final_update.add(fac.UpdateInstruction(cc_13, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ProsessinOmistajaNimi')), None)
     st_15 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_15)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_13, False))
+    final_update.add(fac.UpdateInstruction(cc_14, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KokoavanProsessitunnuksenLahdeTeksti')), None)
     st_16 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_16)
     final_update = set()
-    final_update.add(fac.UpdateInstruction(cc_14, False))
+    final_update.add(fac.UpdateInstruction(cc_15, False))
     symbol = pyxb.binding.content.ElementUse(kasittelyprosessiTiedotTyyppi._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Laajennos')), None)
     st_17 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_17)
@@ -3086,276 +3089,304 @@ def _BuildAutomaton_10 ():
     transitions = []
     transitions.append(fac.Transition(st_3, [
          ]))
+    transitions.append(fac.Transition(st_4, [
+         ]))
+    transitions.append(fac.Transition(st_5, [
+         ]))
+    transitions.append(fac.Transition(st_6, [
+         ]))
+    transitions.append(fac.Transition(st_7, [
+         ]))
+    transitions.append(fac.Transition(st_8, [
+         ]))
+    transitions.append(fac.Transition(st_9, [
+         ]))
+    transitions.append(fac.Transition(st_10, [
+         ]))
+    transitions.append(fac.Transition(st_11, [
+         ]))
+    transitions.append(fac.Transition(st_12, [
+         ]))
+    transitions.append(fac.Transition(st_13, [
+         ]))
+    transitions.append(fac.Transition(st_14, [
+         ]))
+    transitions.append(fac.Transition(st_15, [
+         ]))
+    transitions.append(fac.Transition(st_16, [
+         ]))
+    transitions.append(fac.Transition(st_17, [
+         ]))
     st_2._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_3, [
-         ]))
+        fac.UpdateInstruction(cc_1, True) ]))
     transitions.append(fac.Transition(st_4, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_5, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_6, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_7, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_8, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_9, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_10, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_11, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_12, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_13, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_14, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_15, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_16, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     transitions.append(fac.Transition(st_17, [
-         ]))
+        fac.UpdateInstruction(cc_1, False) ]))
     st_3._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
+        fac.UpdateInstruction(cc_2, True) ]))
     transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_1, False) ]))
+        fac.UpdateInstruction(cc_2, False) ]))
     st_4._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, True) ]))
+        fac.UpdateInstruction(cc_3, True) ]))
     transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_2, False) ]))
+        fac.UpdateInstruction(cc_3, False) ]))
     st_5._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, True) ]))
+        fac.UpdateInstruction(cc_4, True) ]))
     transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_3, False) ]))
+        fac.UpdateInstruction(cc_4, False) ]))
     st_6._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_4, True) ]))
+        fac.UpdateInstruction(cc_5, True) ]))
     transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_4, False) ]))
+        fac.UpdateInstruction(cc_5, False) ]))
     st_7._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_5, True) ]))
+        fac.UpdateInstruction(cc_6, True) ]))
     transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_5, False) ]))
+        fac.UpdateInstruction(cc_6, False) ]))
     st_8._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_6, True) ]))
+        fac.UpdateInstruction(cc_7, True) ]))
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_6, False) ]))
+        fac.UpdateInstruction(cc_7, False) ]))
     st_9._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_7, True) ]))
+        fac.UpdateInstruction(cc_8, True) ]))
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_7, False) ]))
+        fac.UpdateInstruction(cc_8, False) ]))
     st_10._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_8, True) ]))
+        fac.UpdateInstruction(cc_9, True) ]))
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_8, False) ]))
+        fac.UpdateInstruction(cc_9, False) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_8, False) ]))
+        fac.UpdateInstruction(cc_9, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_8, False) ]))
+        fac.UpdateInstruction(cc_9, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_8, False) ]))
+        fac.UpdateInstruction(cc_9, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_8, False) ]))
+        fac.UpdateInstruction(cc_9, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_8, False) ]))
+        fac.UpdateInstruction(cc_9, False) ]))
     st_11._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_9, True) ]))
+        fac.UpdateInstruction(cc_10, True) ]))
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_9, False) ]))
+        fac.UpdateInstruction(cc_10, False) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_9, False) ]))
+        fac.UpdateInstruction(cc_10, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_9, False) ]))
+        fac.UpdateInstruction(cc_10, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_9, False) ]))
+        fac.UpdateInstruction(cc_10, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_9, False) ]))
+        fac.UpdateInstruction(cc_10, False) ]))
     st_12._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_10, True) ]))
+        fac.UpdateInstruction(cc_11, True) ]))
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_10, False) ]))
+        fac.UpdateInstruction(cc_11, False) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_10, False) ]))
+        fac.UpdateInstruction(cc_11, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_10, False) ]))
+        fac.UpdateInstruction(cc_11, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_10, False) ]))
+        fac.UpdateInstruction(cc_11, False) ]))
     st_13._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_11, True) ]))
+        fac.UpdateInstruction(cc_12, True) ]))
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_11, False) ]))
+        fac.UpdateInstruction(cc_12, False) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_11, False) ]))
+        fac.UpdateInstruction(cc_12, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_11, False) ]))
+        fac.UpdateInstruction(cc_12, False) ]))
     st_14._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_12, True) ]))
+        fac.UpdateInstruction(cc_13, True) ]))
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_12, False) ]))
+        fac.UpdateInstruction(cc_13, False) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_12, False) ]))
+        fac.UpdateInstruction(cc_13, False) ]))
     st_15._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_13, True) ]))
+        fac.UpdateInstruction(cc_14, True) ]))
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_13, False) ]))
+        fac.UpdateInstruction(cc_14, False) ]))
     st_16._set_transitionSet(transitions)
     transitions = []
     transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_14, True) ]))
+        fac.UpdateInstruction(cc_15, True) ]))
     st_17._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
 kasittelyprosessiTiedotTyyppi._Automaton = _BuildAutomaton_10()

--- a/metarecord/binding/jhs.py
+++ b/metarecord/binding/jhs.py
@@ -1,7 +1,7 @@
 # ./metarecord/binding/jhs.py
 # -*- coding: utf-8 -*-
 # PyXB bindings for NM:0bcf4fe07fa483312851437fc9b3f33582a4d3fa
-# Generated 2020-04-02 13:07:27.746666 by PyXB version 1.2.6 using Python 3.6.10.final.0
+# Generated 2020-04-06 06:44:21.533676 by PyXB version 1.2.6 using Python 3.6.10.final.0
 # Namespace http://skeemat.jhs-suositukset.fi/tos/2015/01/15
 
 from __future__ import unicode_literals
@@ -14,7 +14,7 @@ import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:e7074e5c-74e2-11ea-80ec-0242ac1e0003')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0bd4d60e-77d2-11ea-a270-0242c0a80003')
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = '1.2.6'
@@ -278,6 +278,8 @@ henkilotietoluonneKoodiTyyppi._CF_enumeration = pyxb.binding.facets.CF_enumerati
 henkilotietoluonneKoodiTyyppi._CF_enumeration.addEnumeration(unicode_value='1', tag=None)
 henkilotietoluonneKoodiTyyppi._CF_enumeration.addEnumeration(unicode_value='2', tag=None)
 henkilotietoluonneKoodiTyyppi._CF_enumeration.addEnumeration(unicode_value='3', tag=None)
+henkilotietoluonneKoodiTyyppi._CF_enumeration.addEnumeration(unicode_value='4', tag=None)
+henkilotietoluonneKoodiTyyppi._CF_enumeration.addEnumeration(unicode_value='5', tag=None)
 henkilotietoluonneKoodiTyyppi._InitializeFacetMap(henkilotietoluonneKoodiTyyppi._CF_enumeration)
 Namespace.addCategoryObject('typeBinding', 'henkilotietoluonneKoodiTyyppi', henkilotietoluonneKoodiTyyppi)
 _module_typeBindings.henkilotietoluonneKoodiTyyppi = henkilotietoluonneKoodiTyyppi

--- a/metarecord/exporter/jhs.py
+++ b/metarecord/exporter/jhs.py
@@ -29,7 +29,9 @@ class JHSExporter:
         'PersonalData': {
             'Ei sisällä henkilötietoja': '1',
             'Sisältää henkilötietoja': '2',
-            'Sisältää arkaluonteisia henkilötietoja': '3'
+            'Sisältää arkaluonteisia henkilötietoja': '3',
+            'Sisältää erityisiä henkilötietoja': '4',
+            'Sisältää rikoksiin tai rikkomuksiin liittyvää henkilötietoa': '5',
         }
     }
 

--- a/metarecord/exporter/jhs.py
+++ b/metarecord/exporter/jhs.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 import pyxb
@@ -8,6 +9,8 @@ import pytz
 
 from metarecord.binding import jhs
 from metarecord.models import Function, Classification
+
+logger = logging.getLogger(__name__)
 
 
 class JHSExporterException(Exception):
@@ -34,13 +37,6 @@ class JHSExporter:
             'Sisältää rikoksiin tai rikkomuksiin liittyvää henkilötietoa': '5',
         }
     }
-
-    def __init__(self, output=False):
-        self.output = output
-
-    def msg(self, text):
-        if self.output:
-            print(text)
 
     def _get_attribute_value(self, obj, attribute_identifier):
         value = obj.attributes.get(attribute_identifier)
@@ -72,6 +68,7 @@ class JHSExporter:
         )
 
     def _handle_record(self, record):
+        logger.info("Handling record %s" % record.pk)
         information_system = self._get_attribute_value(record, 'InformationSystem')
 
         return jhs.Asiakirjatieto(
@@ -86,6 +83,7 @@ class JHSExporter:
         )
 
     def _handle_action(self, action, records):
+        logger.info("Handling action %s" % action.pk)
         ToimenpideTiedot = jhs.Toimenpidetiedot(
             id=action.uuid,
             Asiakirjatieto=records,
@@ -101,6 +99,7 @@ class JHSExporter:
         return ToimenpideTiedot
 
     def _handle_phase(self, phase, actions):
+        logger.info("Handling phase %s" % phase.pk)
         ToimenpideTiedot = jhs.Toimenpidetiedot(
             id=phase.uuid,
             Toimenpidetiedot=actions
@@ -116,6 +115,7 @@ class JHSExporter:
         return ToimenpideTiedot
 
     def _handle_function(self, function, phases):
+        logger.info("Handling function %s" % function.pk)
         information_system = self._get_attribute_value(function, 'InformationSystem')
         handling_process_info = jhs.KasittelyprosessiTiedot(
             id=uuid.uuid4(),
@@ -144,7 +144,8 @@ class JHSExporter:
                 Nimeke=jhs.Nimeke(jhs.NimekeKielella(classification.title, kieliKoodi='fi')),
             )
 
-        self.msg('processing function %s' % function)
+        logger.info('Processing function %s' % function)
+
         phases = []
         handling = None
         try:
@@ -164,16 +165,16 @@ class JHSExporter:
         except Exception as e:
             error = '%s: %s' % (e.__class__.__name__, e)
             if handling:
-                self.msg('ERROR %s while processing %s' % (error, handling))
+                logger.error('ERROR %s while processing %s' % (error, handling))
                 return False
             else:
-                self.msg('ERROR %s' % error)
+                logger.error(error)
                 return False
         if func:
             try:
                 func.toDOM()  # validates
             except pyxb.PyXBException as e:
-                self.msg('ERROR validating the function, details:\n%s' % e.details())
+                logger.error('ERROR validating the function, details:\n%s' % e.details())
                 return False
 
         return func
@@ -208,7 +209,7 @@ class JHSExporter:
                 classifications.append(item)
 
         classifications.sort(key=lambda a: a.Luokitustunnus)
-        self.msg('creating the actual XML...')
+        logger.info('Creating the actual XML...')
 
         tos_root = jhs.Tos(
             TosTiedot=tos_info,
@@ -218,20 +219,20 @@ class JHSExporter:
         try:
             dom = tos_root.toDOM()
         except pyxb.PyXBException as e:
-            self.msg('ERROR while creating the XML file: %s' % e.details())
+            logger.error('ERROR while creating the XML file: %s' % e.details())
             raise JHSExporterException(e.details())
 
         return dom.toprettyxml(' ', encoding='utf-8')
 
     def export_data(self, filename):
-        self.msg('exporting data...')
+        logger.info('Exporting data...')
         xml = self.create_xml()
 
         try:
             with open(filename, 'wb') as f:
-                self.msg('writing to the file...')
+                logger.info('Writing to the file...')
                 f.write(xml)
-                self.msg('Done.')
+                logger.info('File written')
         except Exception as e:
-            self.msg('ERROR writing to the file: %s' % e)
+            logger.error('ERROR writing to the file: %s' % e)
             raise JHSExporterException(e)

--- a/metarecord/management/commands/export_data.py
+++ b/metarecord/management/commands/export_data.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         filename = options['filename']
-        jhs_exporter = JHSExporter(output=True)
+        jhs_exporter = JHSExporter()
 
         try:
             jhs_exporter.export_data(filename)

--- a/metarecord/management/commands/update_saved_jhs_file.py
+++ b/metarecord/management/commands/update_saved_jhs_file.py
@@ -7,12 +7,7 @@ class Command(BaseCommand):
 
     help = "Update new version of JHS191 XML to saved file used as a cache."
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--output",
-            action="store_true",
-            help="Print output to terminal",
-        )
-
     def handle(self, *args, **options):
-        create_saved_jhs_xml(output=options["output"])
+        self.stdout.write("Generating XML file...")
+        create_saved_jhs_xml()
+        self.stdout.write("XML file generated!")

--- a/metarecord/views/export.py
+++ b/metarecord/views/export.py
@@ -14,9 +14,9 @@ from metarecord.views.function import FunctionFilterSet
 logger = logging.getLogger(__name__)
 
 
-def create_saved_jhs_xml(output=False):
+def create_saved_jhs_xml():
     try:
-        exporter = JHSExporter(output=output)
+        exporter = JHSExporter()
         xml = exporter.create_xml()
         save_jhs_export_to_file(xml)
 
@@ -44,7 +44,7 @@ def save_jhs_export_to_file(xml):
 
 class ExportView(APIView):
     def get(self, request, format=None):
-        exporter = JHSExporter(output=True)
+        exporter = JHSExporter()
         queryset = exporter.get_queryset()
 
         queryset = FunctionFilterSet(request.query_params, queryset=queryset, request=request).qs


### PR DESCRIPTION
Implement various improvements to the JHS191 XML exporter. These improvements make the exporter easier to debug and address couple issues that cause the exporter to silently fail and omit some classifications from the generated XML.

* Mark `KasittelyprosessiTiedot/Toimenpidetiedot` as non required
* Recognise two new values for `PersonalData` metadata field
* Implement proper logging for `JHSExporter`
* Add `./export` directory to gitignore

Resolves #256 