### PR TITLE
Fix usage of deprecated function in TOS import

### DIFF
--- a/metarecord/importer/tos.py
+++ b/metarecord/importer/tos.py
@@ -139,7 +139,12 @@ class TOSImporter:
         headers = [sheet.cell(row=1, column=x).value for x in range(1, max_col)]
         headers = [self._clean_header(s) for s in headers if s]
         data = []
-        cells = sheet.get_squared_range(1, data_row, max_col, sheet.max_row + 1)
+        cells = sheet.iter_rows(
+            min_row=data_row,
+            max_row=sheet.max_row + 1,
+            min_col=1,
+            max_col=max_col,
+        )
         for row in cells:
             attrs = {}
             for col, attr in enumerate(headers):


### PR DESCRIPTION
TOS excel importer used `get_squared_range` worksheet method which has
been deprecated since openpyxl 2.4.1 (10/2016). It was finally removed
in 2.6.0 (02/2019).

Use `iter_rows` instead as suggested by the deprecation warning.

Resolves https://github.com/City-of-Helsinki/helerm/issues/258