### PR TITLE
Fix incorrect references to User object in views

### DIFF
--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -598,7 +598,7 @@ def test_function_modified_by(function, user_api_client, user):
     assert response.data['modified_by'] is None
 
     function.modified_by = user
-    function.save(update_fields=('modified_by',))
+    function.save()
 
     response = user_api_client.get(get_function_detail_url(function))
     assert response.status_code == 200
@@ -609,7 +609,7 @@ def test_function_modified_by(function, user_api_client, user):
 def test_function_anonymous_cannot_view_modified_by(function, api_client, user):
     function.state = Function.APPROVED
     function.modified_by = user
-    function.save(update_fields=('modified_by', 'state'))
+    function.save()
 
     response = api_client.get(get_function_detail_url(function))
     assert response.status_code == 200
@@ -619,7 +619,7 @@ def test_function_anonymous_cannot_view_modified_by(function, api_client, user):
 @pytest.mark.django_db
 def test_function_user_cannot_view_modified_by(function, user_api_client, user):
     function.modified_by = user
-    function.save(update_fields=('modified_by',))
+    function.save()
 
     response = user_api_client.get(get_function_detail_url(function))
     assert response.status_code == 200
@@ -629,7 +629,7 @@ def test_function_user_cannot_view_modified_by(function, user_api_client, user):
 @pytest.mark.django_db
 def test_function_another_user_cannot_view_modified_by(function, user_2_api_client, user):
     function.modified_by = user
-    function.save(update_fields=('modified_by',))
+    function.save()
 
     response = user_2_api_client.get(get_function_detail_url(function))
     assert response.status_code == 200
@@ -1966,7 +1966,7 @@ def test_bulk_update_modified_by_display(bulk_update, user_api_client, permissio
 
     bulk_update.created_by = user_api_client.user
     bulk_update.modified_by = user_api_client.user
-    bulk_update.save(update_fields=['modified_by'])
+    bulk_update.save()
 
     response = user_api_client.get(get_bulk_update_detail_url(bulk_update))
     response_data = json.loads(response.content.decode('utf-8'))

--- a/metarecord/views/bulk_update.py
+++ b/metarecord/views/bulk_update.py
@@ -43,22 +43,19 @@ class BulkUpdateSerializer(serializers.ModelSerializer):
 
         return fields
 
-    def _get_user_name_display(self, user):
-        return '{} {}'.format(user.first_name, user.last_name).strip()
-
     def get_approved_by(self, obj):
         user = self.context['request'].user
 
-        if obj.approved_by and user.has_perm(Function.CAN_VIEW_MODIFIED_BY):
-            return self._get_user_name_display(obj.approved_by)
+        if user.has_perm(Function.CAN_VIEW_MODIFIED_BY):
+            return obj._approved_by or None
 
         return None
 
     def get_modified_by(self, obj):
         user = self.context['request'].user
 
-        if obj.modified_by and user.has_perm(Function.CAN_VIEW_MODIFIED_BY):
-            return self._get_user_name_display(obj.modified_by)
+        if user.has_perm(Function.CAN_VIEW_MODIFIED_BY):
+            return obj._modified_by or None
 
         return None
 

--- a/metarecord/views/function.py
+++ b/metarecord/views/function.py
@@ -99,9 +99,7 @@ class FunctionListSerializer(StructuralElementSerializer):
         return function
 
     def get_modified_by(self, obj):
-        if obj.modified_by:
-            return '{} {}'.format(obj.modified_by.first_name, obj.modified_by.last_name).strip()
-        return None
+        return obj._modified_by or None
 
     def get_parent(self, obj):
         if obj.classification and obj.classification.parent:


### PR DESCRIPTION
User names should be read from the char fields that are updated to
contain the name of the related user whenever the model instance is
updated.

Update some tests to not use `update_fields` when saving a model
instance because that interferes with updating the char field value.