### PR TITLE
Implement Record detail API endpoint

### DIFF
--- a/helerm/urls.py
+++ b/helerm/urls.py
@@ -4,12 +4,13 @@ from rest_framework.routers import DefaultRouter
 
 from metarecord.views import (
     AttributeViewSet, BulkUpdateViewSet, ClassificationViewSet, ExportView, FunctionViewSet, JHSExportViewSet,
-    TemplateViewSet
+    RecordViewSet, TemplateViewSet
 )
 from users.views import UserViewSet
 
 router = DefaultRouter()
 router.register(r'function', FunctionViewSet)
+router.register(r'record', RecordViewSet)
 router.register(r'attribute', AttributeViewSet)
 router.register(r'template', TemplateViewSet, basename='template')
 router.register(r'user', UserViewSet)

--- a/metarecord/views/__init__.py
+++ b/metarecord/views/__init__.py
@@ -3,4 +3,5 @@ from .bulk_update import BulkUpdateViewSet  # noqa
 from .classification import ClassificationViewSet  # noqa
 from .export import ExportView, JHSExportViewSet  # noqa
 from .function import FunctionViewSet  # noqa
+from .record import RecordViewSet  # noqa
 from .template import TemplateViewSet  # noqa

--- a/metarecord/views/record.py
+++ b/metarecord/views/record.py
@@ -1,0 +1,22 @@
+from rest_framework import serializers, viewsets
+from rest_framework.mixins import RetrieveModelMixin
+
+from metarecord.models import Record
+from metarecord.views.base import StructuralElementSerializer
+
+
+class RecordSerializer(StructuralElementSerializer):
+    modified_by = serializers.SerializerMethodField()
+
+    class Meta(StructuralElementSerializer.Meta):
+        model = Record
+        exclude = StructuralElementSerializer.Meta.exclude + ('_created_by', '_modified_by')
+
+    def get_modified_by(self, obj):
+        return obj._modified_by or None
+
+
+class RecordViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
+    serializer_class = RecordSerializer
+    queryset = Record.objects.all()
+    lookup_field = 'uuid'


### PR DESCRIPTION
Implement Record detail API endpoint so that Record instance information
can be fetched from the API with the record UUID. This is so that
external systems can reference the Record with a permanent link that
will stay unchanged.

Resolves #281