### PR TITLE
Upgrade Sentry support package

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ django-allauth
 djangorestframework-jwt
 django-admin-sortable2
 djangorestframework-xml
+sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2020.6.20        # via requests
+certifi==2020.6.20        # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid
 django-admin-sortable2==0.7.7  # via -r requirements.in
@@ -37,6 +37,7 @@ pyxb==1.2.6               # via -r requirements.in
 requests-oauthlib==1.3.0  # via django-allauth
 requests==2.24.0          # via django-allauth, django-helusers, pyjwkest, requests-oauthlib
 rsa==4.6                  # via python-jose
+sentry-sdk==0.18.0        # via -r requirements.in
 six==1.15.0               # via ecdsa, pyjwkest, python-jose
 sqlparse==0.3.1           # via django
-urllib3==1.25.10          # via requests
+urllib3==1.25.10          # via requests, sentry-sdk


### PR DESCRIPTION
Old sentry support package (raven) was broken and unmaintained.
Change HelERM to use the newer sentry-sdk.