### PR TITLE
Handle Function `bulk_update` on PUT requests

### DIFF
--- a/metarecord/tests/test_api.py
+++ b/metarecord/tests/test_api.py
@@ -79,7 +79,7 @@ def post_function_data(classification, free_text_attribute, choice_attribute):
 
 
 @pytest.fixture
-def put_function_data(function, free_text_attribute, choice_attribute):
+def put_function_data(function, free_text_attribute, choice_attribute, bulk_update):
     return {
         'name': 'new function version',
         'function_id': function.classification.code,
@@ -105,7 +105,8 @@ def put_function_data(function, free_text_attribute, choice_attribute):
                     }
                 ]
             }
-        ]
+        ],
+        'bulk_update': bulk_update.id,
     }
 
 

--- a/metarecord/views/function.py
+++ b/metarecord/views/function.py
@@ -53,6 +53,8 @@ class FunctionListSerializer(StructuralElementSerializer):
     classification_code = serializers.ReadOnlyField(source='get_classification_code')
     classification_title = serializers.ReadOnlyField(source='get_name')
 
+    bulk_update = serializers.SerializerMethodField()
+
     # TODO these three are here to maintain backwards compatibility,
     # should be removed as soon as the UI doesn't need these anymore
     function_id = serializers.ReadOnlyField(source='get_classification_code')
@@ -147,6 +149,9 @@ class FunctionListSerializer(StructuralElementSerializer):
             if parent_functions.exists():
                 return parent_functions[0].uuid.hex
         return None
+
+    def get_bulk_update(self, obj):
+        return obj.bulk_update.id if obj.bulk_update else None
 
     def validate(self, data):
         new_valid_from = data.get('valid_from')


### PR DESCRIPTION
Get the `bulk_update` UUID instead of the whole object when updating an existing Function.

Refs -