### PR TITLE
Add ElasticSearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ addons:
     - postgresql-10
     - postgresql-client-10
 
+env:
+  - ELASTICSEARCH_HOST: localhost:9200
+before_install:
+  - curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.3.2-amd64.deb -o elasticsearch.deb
+  - sudo dpkg -i --force-confnew elasticsearch.deb
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+  - sudo service elasticsearch restart
+before_script:
+  - sleep 10 # Needed for ElasticSearch
 install:
 - pip install --upgrade pip
 - pip install coveralls -r requirements.txt -r dev-requirements.txt

--- a/config_dev.env.example
+++ b/config_dev.env.example
@@ -150,3 +150,6 @@ STATIC_URL=/static/
 # Sentry environment is an optional tag that can be included in sentry
 # reports. It is used to separate deployments within Sentry UI
 SENTRY_ENVIRONMENT=local-development-unconfigured
+
+# Host for ElasticSearch connection.
+#ELASTICSEARCH_HOST=helerm_elasticsearch:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,27 @@ services:
       - helerm_postgres-data-volume:/var/lib/postgresql/data
     container_name: helerm_postgres
 
+  elasticsearch:
+    image: elasticsearch:7.3.2
+    build:
+      context: .
+      dockerfile: ./docker/elasticsearch/Dockerfile
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - cluster.routing.allocation.disk.watermark.low=97%
+      - cluster.routing.allocation.disk.watermark.high=98%
+      - cluster.routing.allocation.disk.watermark.flood_stage=99%
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Djava.security.policy=file:/usr/share/elasticsearch/plugins/elasticsearch-analysis-voikko/plugin-security.policy"
+    container_name: helerm_elasticsearch
+
   django:
     build: .
     command: bash -c 'tail -f /dev/null'
+    environment:
+      ELASTICSEARCH_HOST: helerm_elasticsearch
     volumes:
       - .:/code
     ports:

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,0 +1,14 @@
+FROM elasticsearch:7.3.2
+
+# Installation of the voikko library and plugin for ElasticSearch
+# https://github.com/EvidentSolutions/elasticsearch-analysis-voikko
+RUN yum install -y \
+    unzip \
+    libvoikko
+
+RUN curl -o /usr/lib64/voikko/morpho.zip https://www.puimula.org/htp/testing/voikko-snapshot/dict-morpho.zip
+RUN unzip -o /usr/lib64/voikko/morpho.zip -d /usr/lib64/voikko/
+
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://github.com/EvidentSolutions/elasticsearch-analysis-voikko/releases/download/v0.6.0/elasticsearch-analysis-voikko-0.6.0.zip \
+&& echo '-Djava.security.policy=file:/usr/share/elasticsearch/plugins/elasticsearch-analysis-voikko/plugin-security.policy' >> /usr/share/elasticsearch/config/jvm.options \
+|| echo "Plugin already exists."

--- a/helerm/settings.py
+++ b/helerm/settings.py
@@ -67,6 +67,7 @@ env = environ.Env(
     PATH_PREFIX=(str, '/'),
     INTERNAL_IPS=(list, []),
     HELERM_JHS191_EXPORT_DESCRIPTION=(str, 'exported from undefined environment'),
+    ELASTICSEARCH_HOST=(str, "helerm_elasticsearch:9200"),
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -114,8 +115,11 @@ INSTALLED_APPS = [
     'helusers.providers.helsinki',
     'adminsortable2',
     'django_filters',
+    'django_elasticsearch_dsl',
+    'django_elasticsearch_dsl_drf',
 
     'metarecord',
+    'search_indices',
     'users',
 ]
 
@@ -314,6 +318,24 @@ REST_FRAMEWORK = {
         'rest_framework_xml.renderers.XMLRenderer',
     ),
 }
+
+
+# Elasticsearch configuration
+ELASTICSEARCH_DSL = {
+    'default': {
+        'hosts': env("ELASTICSEARCH_HOST")
+    },
+}
+
+# Name of the Elasticsearch index
+ELASTICSEARCH_INDEX_NAMES = {
+    'search_indices.documents.action': 'action',
+    'search_indices.documents.function': 'function',
+    'search_indices.documents.classification': 'classification',
+    'search_indices.documents.phase': 'phase',
+    'search_indices.documents.record': 'record',
+}
+
 
 # Django SECRET_KEY setting, used for password reset links and such
 SECRET_KEY = env('SECRET_KEY')

--- a/helerm/urls.py
+++ b/helerm/urls.py
@@ -6,6 +6,14 @@ from metarecord.views import (
     AttributeViewSet, BulkUpdateViewSet, ClassificationViewSet, ExportView, FunctionViewSet, JHSExportViewSet,
     RecordViewSet, TemplateViewSet
 )
+from search_indices.views import (
+    ActionSearchDocumentViewSet,
+    AllSearchDocumentViewSet,
+    ClassificationSearchDocumentViewSet,
+    FunctionSearchDocumentViewSet,
+    PhaseSearchDocumentViewSet,
+    RecordSearchDocumentViewSet,
+)
 from users.views import UserViewSet
 
 router = DefaultRouter()
@@ -17,6 +25,12 @@ router.register(r'user', UserViewSet)
 router.register(r'classification', ClassificationViewSet)
 router.register(r'export/jhs191', JHSExportViewSet, basename='jhs191_export')
 router.register(r'bulk-update', BulkUpdateViewSet)
+router.register(r"action-search", ActionSearchDocumentViewSet, basename='action_search')
+router.register(r"classification-search", ClassificationSearchDocumentViewSet, basename='classification_search')
+router.register(r"function-search", FunctionSearchDocumentViewSet, basename='function_search')
+router.register(r"phase-search", PhaseSearchDocumentViewSet, basename='phase_search')
+router.register(r"record-search", RecordSearchDocumentViewSet, basename='record_search')
+router.register(r"all-search", AllSearchDocumentViewSet, basename='all_search')
 
 urlpatterns = [
     path('v1/', include(router.urls)),

--- a/metarecord/pagination.py
+++ b/metarecord/pagination.py
@@ -1,3 +1,4 @@
+from django_elasticsearch_dsl_drf.pagination import PageNumberPagination as ESPageNumberPagination
 from rest_framework.pagination import PageNumberPagination
 
 
@@ -5,3 +6,7 @@ class MetaRecordPagination(PageNumberPagination):
     page_size = 20
     page_size_query_param = 'page_size'
     max_page_size = 10000
+
+
+class ESRecordPagination(ESPageNumberPagination, MetaRecordPagination):
+    pass

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 Django~=3.1.5
+django-elasticsearch-dsl-drf
 django-environ
 django-helusers
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.3.1            # via django
 authlib==0.15.2           # via drf-oidc-auth
-certifi==2020.12.5        # via requests, sentry-sdk
+certifi==2020.12.5        # via elasticsearch, requests, sentry-sdk
 cffi==1.14.4              # via cryptography
 chardet==4.0.0            # via requests
 cryptography==3.3.1       # via authlib, drf-oidc-auth, pyjwt
@@ -14,15 +14,20 @@ defusedxml==0.6.0         # via djangorestframework-xml, python3-openid
 django-admin-sortable2==0.7.7  # via -r requirements.in
 django-allauth==0.44.0    # via -r requirements.in
 django-cors-headers==3.6.0  # via -r requirements.in
+django-elasticsearch-dsl-drf==0.20.9  # via -r requirements.in
+django-elasticsearch-dsl==7.1.4  # via django-elasticsearch-dsl-drf
 django-environ==0.4.5     # via -r requirements.in
 django-filter==2.4.0      # via -r requirements.in
 django-helusers==0.5.6    # via -r requirements.in
-django==3.1.5             # via -r requirements.in, django-admin-sortable2, django-allauth, django-cors-headers, django-filter, django-helusers, djangorestframework, drf-oidc-auth
+django-nine==0.2.4        # via django-elasticsearch-dsl-drf
+django==3.1.5             # via -r requirements.in, django-admin-sortable2, django-allauth, django-cors-headers, django-filter, django-helusers, django-nine, djangorestframework, drf-oidc-auth
 djangorestframework-jwt==1.11.0  # via -r requirements.in
 djangorestframework-xml==2.0.0  # via -r requirements.in
-djangorestframework==3.12.2  # via -r requirements.in, drf-oidc-auth
+djangorestframework==3.12.2  # via -r requirements.in, django-elasticsearch-dsl-drf, drf-oidc-auth
 drf-oidc-auth==1.0.0      # via django-helusers
 ecdsa==0.14.1             # via python-jose
+elasticsearch-dsl==7.3.0  # via django-elasticsearch-dsl, django-elasticsearch-dsl-drf
+elasticsearch==7.10.1     # via django-elasticsearch-dsl-drf, elasticsearch-dsl
 et-xmlfile==1.0.1         # via openpyxl
 idna==2.10                # via requests
 jdcal==1.4.1              # via openpyxl
@@ -32,6 +37,7 @@ psycopg2==2.8.6           # via -r requirements.in
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via cffi
 pyjwt[crypto]==1.7.1      # via django-allauth, djangorestframework-jwt
+python-dateutil==2.8.1    # via elasticsearch-dsl
 python-jose==3.2.0        # via django-helusers
 python3-openid==3.2.0     # via django-allauth
 pytz==2020.5              # via -r requirements.in, django
@@ -40,6 +46,6 @@ requests-oauthlib==1.3.0  # via django-allauth
 requests==2.25.1          # via django-allauth, django-helusers, drf-oidc-auth, requests-oauthlib
 rsa==4.7                  # via python-jose
 sentry-sdk==0.19.5        # via -r requirements.in
-six==1.15.0               # via cryptography, ecdsa, python-jose
+six==1.15.0               # via cryptography, django-elasticsearch-dsl, django-elasticsearch-dsl-drf, ecdsa, elasticsearch-dsl, python-dateutil, python-jose
 sqlparse==0.4.1           # via django
-urllib3==1.26.2           # via requests, sentry-sdk
+urllib3==1.26.2           # via elasticsearch, requests, sentry-sdk

--- a/search_indices/__init__.py
+++ b/search_indices/__init__.py
@@ -1,0 +1,56 @@
+from elasticsearch_dsl import analyzer, token_filter
+
+from search_indices.utils import create_elasticsearch_connection
+
+
+def get_finnish_stop_filter() -> token_filter:
+    return token_filter("finnish_stop", type="stop", stopwords="_finnish_")
+
+
+def get_finnish_stem_filter() -> token_filter:
+    return token_filter("finnish_stemmer", type="stemmer", language="finnish")
+
+
+def get_edge_ngram_filter() -> token_filter:
+    return token_filter(
+        "custom_edge_ngram_filter",
+        type="edge_ngram",
+        min_gram=3,
+        max_gram=15,
+    )
+
+
+def get_voikko_filter() -> token_filter:
+    return token_filter(
+        "voikko",
+        type="voikko",
+    )
+
+
+def get_finnish_analyzer() -> analyzer:
+    es_connection = create_elasticsearch_connection()
+    if "voikko" in es_connection.cat.plugins():
+        return analyzer(
+            "finnish_analyzer",
+            tokenizer="finnish",
+            filter=[
+                "lowercase",
+                "asciifolding",
+                "unique",
+                get_edge_ngram_filter(),
+                get_voikko_filter(),
+            ],
+        )
+    else:
+        return analyzer(
+            "finnish_analyzer",
+            tokenizer="standard",
+            filter=[
+                "lowercase",
+                "asciifolding",
+                "unique",
+                get_edge_ngram_filter(),
+                get_finnish_stop_filter(),
+                get_finnish_stem_filter(),
+            ],
+        )

--- a/search_indices/backends/faceted_attribute_backend.py
+++ b/search_indices/backends/faceted_attribute_backend.py
@@ -1,0 +1,63 @@
+from typing import List, Type
+
+from django_elasticsearch_dsl import Document
+from django_elasticsearch_dsl_drf.filter_backends.mixins import FilterBackendMixin
+from elasticsearch_dsl.search import Search
+from rest_framework.filters import BaseFilterBackend
+from rest_framework.request import Request
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from search_indices.documents import ActionDocument, FunctionDocument, PhaseDocument, RecordDocument
+
+DOCUMENT_TYPES = [
+    ActionDocument,
+    FunctionDocument,
+    PhaseDocument,
+    RecordDocument,
+]
+
+
+class FacetedAttributeBackend(BaseFilterBackend, FilterBackendMixin):
+    """Adds faceted search for attributes."""
+
+    faceted_search_param = "facet_attribute"
+
+    @staticmethod
+    def get_attributes(documents: List[Type[Document]] = None) -> list:
+        if not documents:
+            documents = DOCUMENT_TYPES
+        attrs = []
+        for document in documents:
+            model = document.Django.model
+            attributes = getattr(model, "_attribute_validations", None)
+            if attributes:
+                attrs += map(
+                    lambda x: f"{str(model._meta.verbose_name)}_{x}",
+                    attributes["allowed"],
+                )
+        return attrs
+
+    def filter_queryset(
+        self, request: Request, queryset: Search, view: Type[ReadOnlyModelViewSet]
+    ) -> Search:
+        """Filter the queryset.
+        :param request: Django REST framework request.
+        :param queryset: Base queryset.
+        :param view: View.
+        :type request: rest_framework.request.Request
+        :type queryset: elasticsearch_dsl.search.Search
+        :type view: rest_framework.viewsets.ReadOnlyModelViewSet
+        :return: Updated queryset.
+        :rtype: elasticsearch_dsl.search.Search
+        """
+        attribute_validations = view.attributes
+        if attribute_validations:
+            for attribute in attribute_validations:
+                attribute_replaced = attribute.replace(".", "+")
+                # Example ("_attribute_Subject.Scheme", "terms", "attributes.Subject+Scheme.keyword")
+                queryset.aggs.bucket(
+                    f"_attribute_{attribute}",
+                    "terms",
+                    field=f"attributes.{attribute_replaced}.keyword",
+                )
+        return queryset

--- a/search_indices/documents/__init__.py
+++ b/search_indices/documents/__init__.py
@@ -1,0 +1,5 @@
+from .action import ActionDocument  # noqa
+from .classification import ClassificationDocument  # noqa
+from .function import FunctionDocument  # noqa
+from .phase import PhaseDocument  # noqa
+from .record import RecordDocument  # noqa

--- a/search_indices/documents/action.py
+++ b/search_indices/documents/action.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django_elasticsearch_dsl import Index
+
+from metarecord.models import Action
+from search_indices import get_finnish_analyzer
+from search_indices.documents.base import BaseDocument
+
+# Name of the Elasticsearch index
+INDEX = Index(settings.ELASTICSEARCH_INDEX_NAMES[__name__])
+
+finnish_analyzer = get_finnish_analyzer()
+
+INDEX.analyzer(finnish_analyzer)
+
+INDEX.settings(
+    max_result_window=500000,
+)
+
+
+@INDEX.document
+class ActionDocument(BaseDocument):
+    class Django:
+        model = Action

--- a/search_indices/documents/base.py
+++ b/search_indices/documents/base.py
@@ -1,0 +1,106 @@
+from typing import Optional
+
+from django_elasticsearch_dsl import Document, fields
+
+from metarecord.models import Action, Classification, Function, Phase, StructuralElement
+from search_indices import get_finnish_analyzer
+from search_indices.documents.utils import prepare_attributes
+
+finnish_analyzer = get_finnish_analyzer()
+
+
+class BaseDocument(Document):
+    id = fields.KeywordField(attr="uuid.hex")
+
+    title = fields.TextField(
+        analyzer=finnish_analyzer,
+        fields={
+            "keyword": fields.KeywordField(),
+        },
+    )
+
+    description = fields.TextField(
+        analyzer=finnish_analyzer,
+        fields={
+            "keyword": fields.KeywordField(),
+        },
+    )
+
+    description_internal = fields.TextField(
+        analyzer=finnish_analyzer,
+        fields={
+            "keyword": fields.KeywordField(),
+        },
+    )
+
+    additional_information = fields.TextField(
+        analyzer=finnish_analyzer,
+        fields={
+            "keyword": fields.KeywordField(),
+        },
+    )
+
+    state = fields.KeywordField()
+
+    code = fields.KeywordField()
+
+    type = fields.IntegerField()
+
+    parent = fields.ObjectField(
+        properties={
+            "id": fields.KeywordField(attr="uuid.hex"),
+            "title": fields.KeywordField(),
+            "version": fields.IntegerField(),
+        }
+    )
+
+    attributes = fields.ObjectField(dynamic=True)
+
+    def prepare_title(self, obj: StructuralElement) -> Optional[str]:
+        title = getattr(obj, "title", None)
+        if not title:
+            title = getattr(obj, "name", None)
+        return title
+
+    def prepare_description(self, obj: StructuralElement) -> Optional[str]:
+        return getattr(obj, "description", None)
+
+    def prepare_description_internal(self, obj: StructuralElement) -> Optional[str]:
+        return getattr(obj, "description_internal", None)
+
+    def prepare_additional_information(self, obj: StructuralElement) -> Optional[str]:
+        return getattr(obj, "additional_information", None)
+
+    def prepare_state(self, obj: StructuralElement) -> Optional[str]:
+        return getattr(obj, "state", None)
+
+    def prepare_code(self, obj: StructuralElement) -> Optional[str]:
+        return getattr(obj, "code", None)
+
+    def prepare_type(self, obj: StructuralElement) -> int:
+        obj_type = type(obj)
+        if obj_type == Classification:
+            return 1
+        elif obj_type == Function:
+            return 2
+        elif obj_type == Phase:
+            return 3
+        elif obj_type == Action:
+            return 4
+        return 5
+
+    def prepare_parent(self, obj: StructuralElement) -> Optional[dict]:
+        parent = getattr(obj, "parent", None)
+        if parent:
+            return {
+                "id": parent.uuid.hex,
+                "title": self.prepare_title(parent),
+                "version": getattr(parent, "version", None),
+            }
+        return None
+
+    def prepare_attributes(self, obj: Function) -> Optional[dict]:
+        if hasattr(obj, "attributes"):
+            model_name = str(self.Django.model._meta.verbose_name)
+            return prepare_attributes(obj, prefix=f"{model_name}_")
+        return None

--- a/search_indices/documents/classification.py
+++ b/search_indices/documents/classification.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.db.models import QuerySet
+from django_elasticsearch_dsl import Index
+
+from metarecord.models import Classification
+from search_indices import get_finnish_analyzer
+from search_indices.documents.base import BaseDocument
+
+# Name of the Elasticsearch index
+INDEX = Index(settings.ELASTICSEARCH_INDEX_NAMES[__name__])
+
+finnish_analyzer = get_finnish_analyzer()
+
+INDEX.analyzer(finnish_analyzer)
+
+INDEX.settings(
+    max_result_window=500000,
+)
+
+
+@INDEX.document
+class ClassificationDocument(BaseDocument):
+    class Django:
+        model = Classification
+
+    def get_queryset(self) -> QuerySet:
+        return Classification.objects.latest_version()

--- a/search_indices/documents/function.py
+++ b/search_indices/documents/function.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.db.models import QuerySet
+from django_elasticsearch_dsl import Index
+
+from metarecord.models import Function
+from search_indices import get_finnish_analyzer
+from search_indices.documents.base import BaseDocument
+
+# Name of the Elasticsearch index
+INDEX = Index(settings.ELASTICSEARCH_INDEX_NAMES[__name__])
+
+finnish_analyzer = get_finnish_analyzer()
+
+INDEX.analyzer(finnish_analyzer)
+
+INDEX.settings(
+    max_result_window=500000,
+)
+
+
+@INDEX.document
+class FunctionDocument(BaseDocument):
+    class Django:
+        model = Function
+
+    def get_queryset(self) -> QuerySet:
+        return Function.objects.latest_version()

--- a/search_indices/documents/phase.py
+++ b/search_indices/documents/phase.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django_elasticsearch_dsl import Index
+
+from metarecord.models import Phase
+from search_indices import get_finnish_analyzer
+from search_indices.documents.base import BaseDocument
+
+# Name of the Elasticsearch index
+INDEX = Index(settings.ELASTICSEARCH_INDEX_NAMES[__name__])
+
+finnish_analyzer = get_finnish_analyzer()
+
+INDEX.analyzer(finnish_analyzer)
+
+INDEX.settings(
+    max_result_window=500000,
+)
+
+
+@INDEX.document
+class PhaseDocument(BaseDocument):
+    class Django:
+        model = Phase

--- a/search_indices/documents/record.py
+++ b/search_indices/documents/record.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django_elasticsearch_dsl import Index
+
+from metarecord.models import Record
+from search_indices import get_finnish_analyzer
+from search_indices.documents.base import BaseDocument
+
+# Name of the Elasticsearch index
+INDEX = Index(settings.ELASTICSEARCH_INDEX_NAMES[__name__])
+
+finnish_analyzer = get_finnish_analyzer()
+
+INDEX.analyzer(finnish_analyzer)
+
+INDEX.settings(
+    max_result_window=500000,
+)
+
+
+@INDEX.document
+class RecordDocument(BaseDocument):
+    class Django:
+        model = Record

--- a/search_indices/documents/utils.py
+++ b/search_indices/documents/utils.py
@@ -1,0 +1,16 @@
+from metarecord.models.structural_element import StructuralElement
+
+
+def prepare_attributes(obj: StructuralElement, prefix: str = "") -> dict:
+    """
+    ElasticSearch cannot handle attribute names with dots, for example "Subject.Scheme".
+    This is because it tries to interpret Scheme as an attribute for Subject.
+    Fix this by replacing "." with "+" when indexing the Documents.
+    """
+    attributes = {}
+    if obj:
+        attrs = obj.attributes
+        for key, value in attrs.items():
+            key = key.replace(".", "+")
+            attributes[prefix + key] = str(value)
+    return attributes

--- a/search_indices/serializers/action.py
+++ b/search_indices/serializers/action.py
@@ -1,0 +1,7 @@
+from search_indices.documents import ActionDocument
+from search_indices.serializers.base import BaseSearchSerializer
+
+
+class ActionSearchSerializer(BaseSearchSerializer):
+    class Meta:
+        document = ActionDocument

--- a/search_indices/serializers/base.py
+++ b/search_indices/serializers/base.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
+from elasticsearch_dsl.response.hit import Hit
+from rest_framework import serializers
+
+from search_indices.serializers.utils import get_attributes
+
+
+class BaseSearchSerializer(DocumentSerializer):
+    attributes = serializers.SerializerMethodField()
+
+    score = serializers.SerializerMethodField()
+
+    class Meta:
+        fields = (
+            "id",
+            "title",
+            "description",
+            "description_internal",
+            "additional_information",
+            "state",
+            "code",
+            "type",
+            "parent",
+            "attributes",
+            "score",
+        )
+
+    def get_score(self, obj: Hit) -> int:
+        return obj.meta.score
+
+    def get_attributes(self, obj: Hit) -> Optional[dict]:
+        return get_attributes(obj, "attributes")

--- a/search_indices/serializers/classification.py
+++ b/search_indices/serializers/classification.py
@@ -1,0 +1,7 @@
+from search_indices.documents import ClassificationDocument
+from search_indices.serializers.base import BaseSearchSerializer
+
+
+class ClassificationSearchSerializer(BaseSearchSerializer):
+    class Meta:
+        document = ClassificationDocument

--- a/search_indices/serializers/function.py
+++ b/search_indices/serializers/function.py
@@ -1,0 +1,7 @@
+from search_indices.documents import FunctionDocument
+from search_indices.serializers.base import BaseSearchSerializer
+
+
+class FunctionSearchSerializer(BaseSearchSerializer):
+    class Meta:
+        document = FunctionDocument

--- a/search_indices/serializers/phase.py
+++ b/search_indices/serializers/phase.py
@@ -1,0 +1,7 @@
+from search_indices.documents import PhaseDocument
+from search_indices.serializers.base import BaseSearchSerializer
+
+
+class PhaseSearchSerializer(BaseSearchSerializer):
+    class Meta:
+        document = PhaseDocument

--- a/search_indices/serializers/record.py
+++ b/search_indices/serializers/record.py
@@ -1,0 +1,7 @@
+from search_indices.documents import RecordDocument
+from search_indices.serializers.base import BaseSearchSerializer
+
+
+class RecordSearchSerializer(BaseSearchSerializer):
+    class Meta:
+        document = RecordDocument

--- a/search_indices/serializers/utils.py
+++ b/search_indices/serializers/utils.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from elasticsearch_dsl.response.hit import Hit
+
+
+def get_attributes(obj: Hit, attribute_field_name: str) -> Optional[dict]:
+    """
+    Fetch attributes from index and revert the attribute names that
+    have "." replaced with "+".
+    """
+    attrs = getattr(obj, attribute_field_name)
+    if attrs:
+        attributes = {}
+        attrs = attrs.to_dict()
+        for key, value in attrs.items():
+            key = key.replace("+", ".")
+            attributes[key] = value
+        return attributes
+    return None

--- a/search_indices/tests/conftest.py
+++ b/search_indices/tests/conftest.py
@@ -1,0 +1,77 @@
+from elasticsearch.helpers.test import get_test_client
+from elasticsearch_dsl.connections import add_connection
+from pytest import fixture
+
+from metarecord.models import Action, Classification, Function, Phase, Record
+from metarecord.tests.conftest import user, user_api_client  # noqa
+from search_indices.documents import (
+    ActionDocument, ClassificationDocument, FunctionDocument, PhaseDocument, RecordDocument
+)
+
+
+@fixture(scope="session", autouse=True)
+def create_indices():
+    """
+    Initialize all indices with the custom analyzers.
+    """
+    ActionDocument._index.create(ignore=[400, 404])
+    ClassificationDocument._index.create(ignore=[400, 404])
+    FunctionDocument._index.create(ignore=[400, 404])
+    PhaseDocument._index.create(ignore=[400, 404])
+    RecordDocument._index.create(ignore=[400, 404])
+
+
+@fixture(scope="session")
+def es_connection():
+    es_connection = get_test_client()
+    add_connection("default", es_connection)
+    yield es_connection
+
+
+@fixture
+def action(phase):
+    return Action.objects.create(
+        attributes={"AdditionalInformation": "testisana"}, phase=phase, index=1
+    )
+
+
+@fixture
+def classification():
+    return Classification.objects.create(
+        title="testisana",
+        code="00 00",
+        state=Classification.APPROVED,
+        function_allowed=True,
+    )
+
+
+@fixture
+def classification2():
+    return Classification.objects.create(
+        title="testisana ja toinen testisana",
+        code="00 00",
+        state=Classification.APPROVED,
+        function_allowed=True,
+    )
+
+
+@fixture
+def function(classification):
+    return Function.objects.create(
+        attributes={"AdditionalInformation": "testisana"},
+        classification=classification,
+    )
+
+
+@fixture
+def phase(function):
+    return Phase.objects.create(
+        attributes={"AdditionalInformation": "testisana"}, function=function, index=1
+    )
+
+
+@fixture
+def record(action):
+    return Record.objects.create(
+        attributes={"AdditionalInformation": "testisana"}, action=action, index=1
+    )

--- a/search_indices/tests/test_elastic_api.py
+++ b/search_indices/tests/test_elastic_api.py
@@ -1,0 +1,116 @@
+import pytest
+from rest_framework.reverse import reverse
+
+ACTION_LIST_URL = reverse("action_search-list")
+ALL_LIST_URL = reverse("all_search-list")
+CLASSIFICATION_LIST_URL = reverse("classification_search-list")
+FUNCTION_LIST_URL = reverse("function_search-list")
+PHASE_LIST_URL = reverse("phase_search-list")
+RECORD_LIST_URL = reverse("record_search-list")
+
+
+@pytest.mark.django_db
+def test_classification_search_exact(user_api_client, classification):
+    url = ALL_LIST_URL + "?search=testisana"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert classification.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_classification_search_fuzzy1(user_api_client, es_connection, classification):
+    if "voikko" not in str(es_connection.indices.get_settings()):
+        pytest.skip()
+    url = ALL_LIST_URL + "?search=testi"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert classification.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_classification_search_fuzzy2(user_api_client, es_connection, classification):
+    if "voikko" not in str(es_connection.indices.get_settings()):
+        pytest.skip()
+    url = ALL_LIST_URL + "?search=testisanojat"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert classification.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_classification_search_query_string(user_api_client, classification2):
+    url = ALL_LIST_URL + '?search_simple_query_string="testisana ja toinen testisana"'
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert classification2.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_action_filter_attribute_exact(user_api_client, action):
+    url = ACTION_LIST_URL + "?action_AdditionalInformation=testisana"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert action.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_classification_filter_title_exact(
+    user_api_client, es_connection, classification
+):
+    if "voikko" not in str(es_connection.indices.get_settings()):
+        pytest.skip()
+    url = CLASSIFICATION_LIST_URL + f"?title=testisana"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert classification.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_function_filter_attribute_exact(user_api_client, function):
+    url = FUNCTION_LIST_URL + "?function_AdditionalInformation=testisana"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert function.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_phase_filter_attribute_exact(user_api_client, phase):
+    url = PHASE_LIST_URL + "?phase_AdditionalInformation=testisana"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert phase.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+def test_record_filter_attribute_exact(user_api_client, record):
+    url = RECORD_LIST_URL + "?record_AdditionalInformation=testisana"
+    response = user_api_client.get(url)
+    assert response.status_code == 200
+
+    results = response.data["results"] if "results" in response.data else response.data
+    uuids = list(result["id"] for result in results)
+    assert record.uuid.hex in uuids

--- a/search_indices/utils.py
+++ b/search_indices/utils.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+from elasticsearch_dsl import connections
+
+
+def create_elasticsearch_connection():
+    es_host = settings.ELASTICSEARCH_DSL["default"]["hosts"]
+    return connections.create_connection(hosts=[es_host])

--- a/search_indices/views/__init__.py
+++ b/search_indices/views/__init__.py
@@ -1,0 +1,6 @@
+from .action import ActionSearchDocumentViewSet  # noqa
+from .all import AllSearchDocumentViewSet  # noqa
+from .classification import ClassificationSearchDocumentViewSet  # noqa
+from .function import FunctionSearchDocumentViewSet  # noqa
+from .phase import PhaseSearchDocumentViewSet  # noqa
+from .record import RecordSearchDocumentViewSet  # noqa

--- a/search_indices/views/action.py
+++ b/search_indices/views/action.py
@@ -1,0 +1,16 @@
+from search_indices.backends.faceted_attribute_backend import FacetedAttributeBackend
+from search_indices.documents.action import ActionDocument
+from search_indices.serializers.action import ActionSearchSerializer
+from search_indices.views.base import BaseSearchDocumentViewSet
+from search_indices.views.utils import populate_filter_fields_with_attributes
+
+
+class ActionSearchDocumentViewSet(BaseSearchDocumentViewSet):
+    document = ActionDocument
+    serializer_class = ActionSearchSerializer
+
+    filter_fields = {}
+    attributes = FacetedAttributeBackend.get_attributes([ActionDocument])
+    populate_filter_fields_with_attributes(filter_fields, attributes)
+
+    search_fields = tuple(f"attributes.{attribute}" for attribute in attributes)

--- a/search_indices/views/all.py
+++ b/search_indices/views/all.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from elasticsearch_dsl import Search
+
+from search_indices.documents.action import ActionDocument
+from search_indices.serializers.action import ActionSearchSerializer
+from search_indices.views.base import BaseSearchDocumentViewSet
+
+
+class AllSearchDocumentViewSet(BaseSearchDocumentViewSet):
+    document = ActionDocument  # This needs to be filled with a valid Document
+    serializer_class = (
+        ActionSearchSerializer  # This needs to be filled with a valid Serializer
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(AllSearchDocumentViewSet, self).__init__(*args, **kwargs)
+
+        self.search = Search(
+            using=self.client,
+            index=list(settings.ELASTICSEARCH_INDEX_NAMES.values()),
+            doc_type=self.document._doc_type.name,
+        ).sort(*self.ordering)
+        self.search.params(preserve_order=False)

--- a/search_indices/views/base.py
+++ b/search_indices/views/base.py
@@ -1,0 +1,67 @@
+from django_elasticsearch_dsl_drf.filter_backends import (
+    CompoundSearchFilterBackend, FacetedSearchFilterBackend, FilteringFilterBackend,
+    SimpleQueryStringSearchFilterBackend
+)
+from django_elasticsearch_dsl_drf.viewsets import BaseDocumentViewSet
+
+from metarecord.pagination import ESRecordPagination
+from search_indices.backends.faceted_attribute_backend import FacetedAttributeBackend
+from search_indices.views.utils import populate_filter_fields_with_attributes
+
+
+class BaseSearchDocumentViewSet(BaseDocumentViewSet):
+    pagination_class = ESRecordPagination
+    lookup_field = "id"
+    filter_backends = [
+        CompoundSearchFilterBackend,
+        FacetedAttributeBackend,
+        FacetedSearchFilterBackend,
+        FilteringFilterBackend,
+        SimpleQueryStringSearchFilterBackend,
+    ]
+
+    faceted_search_fields = {
+        "title": {
+            "field": "title.keyword",
+            "enabled": True,
+        },
+        "description": {
+            "field": "description.keyword",
+            "enabled": True,
+        },
+        "related_classification": {
+            "field": "related_classification.keyword",
+            "enabled": True,
+        },
+        "internal_description": {
+            "field": "internal_description.keyword",
+            "enabled": True,
+        },
+        "additional_information": {
+            "field": "additional_information.keyword",
+            "enabled": True,
+        },
+        "type": {
+            "field": "type",
+            "enabled": True,
+        },
+    }
+
+    filter_fields = {}
+    attributes = FacetedAttributeBackend.get_attributes()
+    populate_filter_fields_with_attributes(filter_fields, attributes)
+
+    search_fields = (
+        "title",
+        "description",
+        "related_classification",
+        "internal_description",
+        "additional_information",
+    )
+
+    search_fields += tuple(f"attributes.{attribute}" for attribute in attributes)
+
+    ordering = (
+        "type",
+        "_score",
+    )

--- a/search_indices/views/classification.py
+++ b/search_indices/views/classification.py
@@ -1,0 +1,24 @@
+from search_indices.documents.classification import ClassificationDocument
+from search_indices.serializers.classification import ClassificationSearchSerializer
+from search_indices.views.base import BaseSearchDocumentViewSet
+
+
+class ClassificationSearchDocumentViewSet(BaseSearchDocumentViewSet):
+    document = ClassificationDocument
+    serializer_class = ClassificationSearchSerializer
+
+    filter_fields = {
+        "title": "title",
+        "description": "description",
+        "related_classification": "related_classification",
+        "internal_description": "internal_description",
+        "additional_information": "additional_information",
+    }
+
+    search_fields = (
+        "title",
+        "description",
+        "related_classification",
+        "internal_description",
+        "additional_information",
+    )

--- a/search_indices/views/function.py
+++ b/search_indices/views/function.py
@@ -1,0 +1,16 @@
+from search_indices.backends.faceted_attribute_backend import FacetedAttributeBackend
+from search_indices.documents.function import FunctionDocument
+from search_indices.serializers.function import FunctionSearchSerializer
+from search_indices.views.base import BaseSearchDocumentViewSet
+from search_indices.views.utils import populate_filter_fields_with_attributes
+
+
+class FunctionSearchDocumentViewSet(BaseSearchDocumentViewSet):
+    document = FunctionDocument
+    serializer_class = FunctionSearchSerializer
+
+    filter_fields = {}
+    attributes = FacetedAttributeBackend.get_attributes([FunctionDocument])
+    populate_filter_fields_with_attributes(filter_fields, attributes)
+
+    search_fields = tuple(f"attributes.{attribute}" for attribute in attributes)

--- a/search_indices/views/phase.py
+++ b/search_indices/views/phase.py
@@ -1,0 +1,16 @@
+from search_indices.backends.faceted_attribute_backend import FacetedAttributeBackend
+from search_indices.documents.phase import PhaseDocument
+from search_indices.serializers.phase import PhaseSearchSerializer
+from search_indices.views.base import BaseSearchDocumentViewSet
+from search_indices.views.utils import populate_filter_fields_with_attributes
+
+
+class PhaseSearchDocumentViewSet(BaseSearchDocumentViewSet):
+    document = PhaseDocument
+    serializer_class = PhaseSearchSerializer
+
+    filter_fields = {}
+    attributes = FacetedAttributeBackend.get_attributes([PhaseDocument])
+    populate_filter_fields_with_attributes(filter_fields, attributes)
+
+    search_fields = tuple(f"attributes.phase_{attribute}" for attribute in attributes)

--- a/search_indices/views/record.py
+++ b/search_indices/views/record.py
@@ -1,0 +1,16 @@
+from search_indices.backends.faceted_attribute_backend import FacetedAttributeBackend
+from search_indices.documents.record import RecordDocument
+from search_indices.serializers.record import RecordSearchSerializer
+from search_indices.views.base import BaseSearchDocumentViewSet
+from search_indices.views.utils import populate_filter_fields_with_attributes
+
+
+class RecordSearchDocumentViewSet(BaseSearchDocumentViewSet):
+    document = RecordDocument
+    serializer_class = RecordSearchSerializer
+
+    filter_fields = {}
+    attributes = FacetedAttributeBackend.get_attributes([RecordDocument])
+    populate_filter_fields_with_attributes(filter_fields, attributes)
+
+    search_fields = tuple(f"attributes.{attribute}" for attribute in attributes)

--- a/search_indices/views/utils.py
+++ b/search_indices/views/utils.py
@@ -1,0 +1,12 @@
+def populate_filter_fields_with_attributes(
+    filter_fields: dict, attributes: list
+) -> None:
+    """
+    Fetch the filter fields from the indexed attributes.
+    """
+    if not attributes:
+        return
+    for attribute in attributes:
+        attribute_replaced = attribute.replace(".", "+")
+        # Example {"Subject.Scheme": "attributes.Subject+Scheme"}
+        filter_fields[attribute] = f"attributes.{attribute_replaced}"


### PR DESCRIPTION
Add the django-elasticsearch-dsl-drf library with its dependencies to integrate ElasticSearch DSL with Django REST Framework. It can be used to create custom REST endpoints alongside the existing ones with search and filter functionalities.

We use ElasticSearch version 7.3.2 to support Finnish search capabilities using  [Voikko Analysis for Elasticsearch](https://github.com/EvidentSolutions/elasticsearch-analysis-voikko). Each level (Classification, Function, Phase, Action, Record) have their own endpoints with search functionalities. In addition there is `all-search` endpoint that enables searching from all the search indices from a single endpoint. The results from the all endpoint is first sorted by the level of the object (classification->function->phase->action->record) and then by the best results according to the score. The other endpoints are sorted by the best results.

The endpoints also provide faceted search results. This means that the search divides the documents to "buckets" according to defined parameters. Here the results are divided according to the attributes for example. The attributes are also categorized according to the types (for example Classification attributes are prefixed with `classification_` -> `classification_Subject`).   

TODO: The search probably needs some work after the attribute reform is done.

Refs #292