### PR TITLE
Replace Allauth with Python Social Auth

### DIFF
--- a/config_dev.env.example
+++ b/config_dev.env.example
@@ -153,3 +153,10 @@ SENTRY_ENVIRONMENT=local-development-unconfigured
 
 # Host for ElasticSearch connection.
 #ELASTICSEARCH_HOST=helerm_elasticsearch:9200
+
+# Helsinki user management library (django-helusers) related OIDC settings.
+SOCIAL_AUTH_TUNNISTAMO_KEY=https://i/am/clientid/in/url/style
+SOCIAL_AUTH_TUNNISTAMO_SECRET=iamyoursecret
+SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT=https://api.hel.fi/sso/openid
+OIDC_API_TOKEN_AUTH_AUDIENCE=https://api.hel.fi/auth/projects
+OIDC_API_TOKEN_AUTH_ISSUER=https://api.hel.fi/sso

--- a/helerm/urls.py
+++ b/helerm/urls.py
@@ -35,6 +35,7 @@ router.register(r"all-search", AllSearchDocumentViewSet, basename='all_search')
 urlpatterns = [
     path('v1/', include(router.urls)),
     path('admin/', admin.site.urls),
-    path('accounts/', include('allauth.urls')),
+    path('pysocial/', include('social_django.urls', namespace='social')),
+    path('helauth/', include('helusers.urls')),
     path('export/', ExportView.as_view(), name='export')
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -9,9 +9,9 @@ pyxb
 djangorestframework
 django-cors-headers
 django-filter
-django-allauth
 django-admin-json-editor
 djangorestframework-jwt
 django-admin-sortable2
 djangorestframework-xml
 sentry-sdk
+social-auth-app-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,10 @@ authlib==0.15.2           # via drf-oidc-auth
 certifi==2020.12.5        # via elasticsearch, requests, sentry-sdk
 cffi==1.14.4              # via cryptography
 chardet==4.0.0            # via requests
-cryptography==3.3.1       # via authlib, drf-oidc-auth, pyjwt
-defusedxml==0.6.0         # via djangorestframework-xml, python3-openid
+cryptography==3.4.6       # via authlib, drf-oidc-auth, social-auth-core
+defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-admin-json-editor==0.2.3  # via -r requirements.in
 django-admin-sortable2==0.7.7  # via -r requirements.in
-django-allauth==0.44.0    # via -r requirements.in
 django-cors-headers==3.6.0  # via -r requirements.in
 django-elasticsearch-dsl-drf==0.20.9  # via -r requirements.in
 django-elasticsearch-dsl==7.1.4  # via django-elasticsearch-dsl-drf
@@ -21,7 +20,7 @@ django-environ==0.4.5     # via -r requirements.in
 django-filter==2.4.0      # via -r requirements.in
 django-helusers==0.5.6    # via -r requirements.in
 django-nine==0.2.4        # via django-elasticsearch-dsl-drf
-django==3.1.5             # via -r requirements.in, django-admin-json-editor, django-admin-sortable2, django-allauth, django-cors-headers, django-filter, django-helusers, django-nine, djangorestframework, drf-oidc-auth
+django==3.1.5             # via -r requirements.in, django-admin-json-editor, django-admin-sortable2, django-cors-headers, django-filter, django-helusers, django-nine, djangorestframework, drf-oidc-auth
 djangorestframework-jwt==1.11.0  # via -r requirements.in
 djangorestframework-xml==2.0.0  # via -r requirements.in
 djangorestframework==3.12.2  # via -r requirements.in, django-elasticsearch-dsl-drf, drf-oidc-auth
@@ -32,21 +31,23 @@ elasticsearch==7.10.1     # via django-elasticsearch-dsl-drf, elasticsearch-dsl
 et-xmlfile==1.0.1         # via openpyxl
 idna==2.10                # via requests
 jdcal==1.4.1              # via openpyxl
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openpyxl==3.0.5           # via -r requirements.in
 psycopg2==2.8.6           # via -r requirements.in
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via cffi
-pyjwt[crypto]==1.7.1      # via django-allauth, djangorestframework-jwt
+pyjwt==1.7.1              # via djangorestframework-jwt, social-auth-core
 python-dateutil==2.8.1    # via elasticsearch-dsl
 python-jose==3.2.0        # via django-helusers
-python3-openid==3.2.0     # via django-allauth
+python3-openid==3.2.0     # via social-auth-core
 pytz==2020.5              # via -r requirements.in, django
 pyxb==1.2.6               # via -r requirements.in
-requests-oauthlib==1.3.0  # via django-allauth
-requests==2.25.1          # via django-allauth, django-helusers, drf-oidc-auth, requests-oauthlib
+requests-oauthlib==1.3.0  # via social-auth-core
+requests==2.25.1          # via django-helusers, drf-oidc-auth, requests-oauthlib, social-auth-core
 rsa==4.7                  # via python-jose
 sentry-sdk==0.19.5        # via -r requirements.in
-six==1.15.0               # via cryptography, django-elasticsearch-dsl, django-elasticsearch-dsl-drf, ecdsa, elasticsearch-dsl, python-dateutil, python-jose
+six==1.15.0               # via django-elasticsearch-dsl, django-elasticsearch-dsl-drf, ecdsa, elasticsearch-dsl, python-dateutil, python-jose, social-auth-app-django, social-auth-core
+social-auth-app-django==4.0.0  # via -r requirements.in
+social-auth-core==4.0.2   # via social-auth-app-django
 sqlparse==0.4.1           # via django
 urllib3==1.26.2           # via elasticsearch, requests, sentry-sdk

--- a/users/migrations/0005_transfer_to_pysocial.py
+++ b/users/migrations/0005_transfer_to_pysocial.py
@@ -1,0 +1,42 @@
+from django.db import connection, migrations
+from django.db.utils import IntegrityError
+
+
+def transfer_users_from_allauth_to_pysocial(apps, schema_editor):
+    """
+    Transfer user UIDs from Allauth to Python Social Auth.
+    Has to be done in raw SQL since Django does not recognize allauth after removing it from the project.
+    """
+    all_tables = connection.introspection.table_names()
+    if "socialaccount_socialaccount" in all_tables:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "INSERT INTO social_auth_usersocialauth (user_id, provider, uid, extra_data, created, modified)"
+                    "SELECT user_id, 'tunnistamo', uid, extra_data, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM socialaccount_socialaccount;"
+                )
+        except IntegrityError:
+            connection._rollback()
+
+
+def remove_sessions(apps, schema_editor):
+    """
+    This needs to be done to get rid of the old sessions because of the
+    added setting SESSION_SERIALIZER.
+    """
+    Session = apps.get_model("sessions", "Session")
+    Session.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0004_longer_first_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            transfer_users_from_allauth_to_pysocial, migrations.RunPython.noop,
+        ),
+        migrations.RunPython(remove_sessions, migrations.RunPython.noop,),
+    ]


### PR DESCRIPTION
- Replace Allauth related settings and urls with Python Social Auth ones.
- Add ENV variables for the settings.
- Create a migration to transfer user connections from Allauth socialaccount table to Pysocial usersocialauth table.

Refs #305