### PR TITLE
Update django & urllib

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django~=3.1.5
+Django~=3.1
 django-elasticsearch-dsl-drf
 django-environ
 django-helusers

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,50 +4,145 @@
 #
 #    pip-compile requirements.in
 #
-asgiref==3.3.1            # via django
-authlib==0.15.2           # via drf-oidc-auth
-certifi==2020.12.5        # via elasticsearch, requests, sentry-sdk
-cffi==1.14.4              # via cryptography
-chardet==4.0.0            # via requests
-cryptography==3.4.6       # via authlib, drf-oidc-auth, social-auth-core
-defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
-django-admin-json-editor==0.2.3  # via -r requirements.in
-django-admin-sortable2==0.7.7  # via -r requirements.in
-django-cors-headers==3.6.0  # via -r requirements.in
-django-elasticsearch-dsl-drf==0.20.9  # via -r requirements.in
-django-elasticsearch-dsl==7.1.4  # via django-elasticsearch-dsl-drf
-django-environ==0.4.5     # via -r requirements.in
-django-filter==2.4.0      # via -r requirements.in
-django-helusers==0.5.6    # via -r requirements.in
-django-nine==0.2.4        # via django-elasticsearch-dsl-drf
-django==3.1.5             # via -r requirements.in, django-admin-json-editor, django-admin-sortable2, django-cors-headers, django-filter, django-helusers, django-nine, djangorestframework, drf-oidc-auth
-djangorestframework-jwt==1.11.0  # via -r requirements.in
-djangorestframework-xml==2.0.0  # via -r requirements.in
-djangorestframework==3.12.2  # via -r requirements.in, django-elasticsearch-dsl-drf, drf-oidc-auth
-drf-oidc-auth==1.0.0      # via django-helusers
-ecdsa==0.14.1             # via python-jose
-elasticsearch-dsl==7.3.0  # via django-elasticsearch-dsl, django-elasticsearch-dsl-drf
-elasticsearch==7.10.1     # via django-elasticsearch-dsl-drf, elasticsearch-dsl
-et-xmlfile==1.0.1         # via openpyxl
-idna==2.10                # via requests
-jdcal==1.4.1              # via openpyxl
-oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-openpyxl==3.0.5           # via -r requirements.in
-psycopg2==2.8.6           # via -r requirements.in
-pyasn1==0.4.8             # via python-jose, rsa
-pycparser==2.20           # via cffi
-pyjwt==1.7.1              # via djangorestframework-jwt, social-auth-core
-python-dateutil==2.8.1    # via elasticsearch-dsl
-python-jose==3.2.0        # via django-helusers
-python3-openid==3.2.0     # via social-auth-core
-pytz==2020.5              # via -r requirements.in, django
-pyxb==1.2.6               # via -r requirements.in
-requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.25.1          # via django-helusers, drf-oidc-auth, requests-oauthlib, social-auth-core
-rsa==4.7                  # via python-jose
-sentry-sdk==0.19.5        # via -r requirements.in
-six==1.15.0               # via django-elasticsearch-dsl, django-elasticsearch-dsl-drf, ecdsa, elasticsearch-dsl, python-dateutil, python-jose, social-auth-app-django, social-auth-core
-social-auth-app-django==4.0.0  # via -r requirements.in
-social-auth-core==4.0.2   # via social-auth-app-django
-sqlparse==0.4.1           # via django
-urllib3==1.26.2           # via elasticsearch, requests, sentry-sdk
+asgiref==3.3.1
+    # via django
+authlib==0.15.2
+    # via drf-oidc-auth
+certifi==2020.12.5
+    # via
+    #   elasticsearch
+    #   requests
+    #   sentry-sdk
+cffi==1.14.4
+    # via cryptography
+chardet==4.0.0
+    # via requests
+cryptography==3.4.6
+    # via
+    #   authlib
+    #   drf-oidc-auth
+    #   social-auth-core
+defusedxml==0.6.0
+    # via
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+django-admin-json-editor==0.2.3
+    # via -r requirements.in
+django-admin-sortable2==0.7.7
+    # via -r requirements.in
+django-cors-headers==3.6.0
+    # via -r requirements.in
+django-elasticsearch-dsl-drf==0.20.9
+    # via -r requirements.in
+django-elasticsearch-dsl==7.1.4
+    # via django-elasticsearch-dsl-drf
+django-environ==0.4.5
+    # via -r requirements.in
+django-filter==2.4.0
+    # via -r requirements.in
+django-helusers==0.5.6
+    # via -r requirements.in
+django-nine==0.2.4
+    # via django-elasticsearch-dsl-drf
+django==3.1.5
+    # via
+    #   -r requirements.in
+    #   django-admin-json-editor
+    #   django-admin-sortable2
+    #   django-cors-headers
+    #   django-filter
+    #   django-helusers
+    #   django-nine
+    #   djangorestframework
+    #   drf-oidc-auth
+djangorestframework-jwt==1.11.0
+    # via -r requirements.in
+djangorestframework-xml==2.0.0
+    # via -r requirements.in
+djangorestframework==3.12.2
+    # via
+    #   -r requirements.in
+    #   django-elasticsearch-dsl-drf
+    #   drf-oidc-auth
+drf-oidc-auth==1.0.0
+    # via django-helusers
+ecdsa==0.14.1
+    # via python-jose
+elasticsearch-dsl==7.3.0
+    # via
+    #   django-elasticsearch-dsl
+    #   django-elasticsearch-dsl-drf
+elasticsearch==7.10.1
+    # via
+    #   django-elasticsearch-dsl-drf
+    #   elasticsearch-dsl
+et-xmlfile==1.0.1
+    # via openpyxl
+idna==2.10
+    # via requests
+jdcal==1.4.1
+    # via openpyxl
+oauthlib==3.1.0
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+openpyxl==3.0.5
+    # via -r requirements.in
+psycopg2==2.8.6
+    # via -r requirements.in
+pyasn1==0.4.8
+    # via
+    #   python-jose
+    #   rsa
+pycparser==2.20
+    # via cffi
+pyjwt==1.7.1
+    # via
+    #   djangorestframework-jwt
+    #   social-auth-core
+python-dateutil==2.8.1
+    # via elasticsearch-dsl
+python-jose==3.2.0
+    # via django-helusers
+python3-openid==3.2.0
+    # via social-auth-core
+pytz==2020.5
+    # via
+    #   -r requirements.in
+    #   django
+pyxb==1.2.6
+    # via -r requirements.in
+requests-oauthlib==1.3.0
+    # via social-auth-core
+requests==2.25.1
+    # via
+    #   django-helusers
+    #   drf-oidc-auth
+    #   requests-oauthlib
+    #   social-auth-core
+rsa==4.7
+    # via python-jose
+sentry-sdk==0.19.5
+    # via -r requirements.in
+six==1.15.0
+    # via
+    #   django-elasticsearch-dsl
+    #   django-elasticsearch-dsl-drf
+    #   ecdsa
+    #   elasticsearch-dsl
+    #   python-dateutil
+    #   python-jose
+    #   social-auth-app-django
+    #   social-auth-core
+social-auth-app-django==4.0.0
+    # via -r requirements.in
+social-auth-core==4.0.2
+    # via social-auth-app-django
+sqlparse==0.4.1
+    # via django
+urllib3==1.26.2
+    # via
+    #   elasticsearch
+    #   requests
+    #   sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ django-helusers==0.5.6
     # via -r requirements.in
 django-nine==0.2.4
     # via django-elasticsearch-dsl-drf
-django==3.1.5
+django==3.1.8
     # via
     #   -r requirements.in
     #   django-admin-json-editor
@@ -141,7 +141,7 @@ social-auth-core==4.0.2
     # via social-auth-app-django
 sqlparse==0.4.1
     # via django
-urllib3==1.26.2
+urllib3==1.26.4
     # via
     #   elasticsearch
     #   requests


### PR DESCRIPTION
Update libraries to silence dependabot alerts.

- Update django 3.1.5 -> 3.1.8
- Update urllib 1.26.2 -> 1.26.4

Refs -