### PR TITLE
Fix postgresql-client-10 repo URL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 
 # Allows installation of postgresql-client-10 on Debian stretch which the Python images are based on
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list
+RUN echo 'deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list
 RUN wget -q -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Dockerfile's broken; Debian stretch isn't supported anymore for PostgreSQL, so the repo URL doesn't work anymore and causes an error. Moved to archive, so use that instead. See: https://www.postgresql.org/message-id/YvZaQJpK2TE0nw%2BK%40msg.df7cb.de

This is a short-term fix; need to do a version update in long-term, but this should at least makes the Dockerfile functional again.