### PR TITLE
TIED-63: Fix docker-compose.yml elasticsearch service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     container_name: helerm_postgres
 
   elasticsearch:
-    image: elasticsearch:7.3.2
     build:
       context: .
       dockerfile: .docker/elasticsearch/Dockerfile


### PR DESCRIPTION
`image` had the same name as the image in the `Dockerfile`, which causes it to layer upon itself every time it's built. This eventually causes a max depth recursion error.

Removing the image parameter seems to fix it.

## Related Issue(s)

**[TIED-63](https://helsinkisolutionoffice.atlassian.net/browse/TIED-63)**



[TIED-63]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ