### PR TITLE
Add --use-pep517 flag in pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install codecov -r requirements.txt -r dev-requirements.txt
+          pip install --use-pep517 codecov -r requirements.txt -r dev-requirements.txt
 
       - name: Configure sysctl limits
         run: |


### PR DESCRIPTION
## Description

Add `--use-pep517` flag in `pip install` command.

## Motivation and Context

Due to warnings such as this:
> DEPRECATION: psycopg2 is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559

[This also seems to be coming sooner than later ](https://github.com/pypa/pip/milestone/68)(2023 Spring at the time of writing).

## Additional notes

From what I understand, this seems to be the way to go until the source package gets updated. The only other option is to pin an older pip version instead.

We'll see what future brings, I suppose ¯\\_(ツ)_/¯

Related discussions I scanned through:
https://github.com/pypa/pip/issues/8368
https://github.com/pypa/pip/issues/8559
https://github.com/pypa/pip/issues/8102