### PR TITLE
Fix: Pin social-auth-core version to 4.2.0 to fix Tunnistamo authentication

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,3 +21,6 @@ djangorestframework-xml
 lxml
 sentry-sdk
 social-auth-app-django
+# Tunnistamo (as of 2023-03-21) doesn't seem to work with
+# social-auth-core 4.3.0 and above.
+social-auth-core==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,8 +139,10 @@ six==1.16.0
     #   python-dateutil
 social-auth-app-django==5.0.0
     # via -r requirements.in
-social-auth-core==4.3.0
-    # via social-auth-app-django
+social-auth-core==4.2.0
+    # via
+    #   -r requirements.in
+    #   social-auth-app-django
 sqlparse==0.4.3
     # via django
 urllib3==1.26.14


### PR DESCRIPTION
## Description

Pin social-auth-core version to 4.2.0 to fix an issue with Tunnistamo.

## Motivation and Context

Tunnistamo raises an `AuthCanceled` error with version >=4.3.0.

## How Has This Been Tested?

Locally against a local Tunnistamo service.
