### PR TITLE
Change ElasticSearch Finnish analyzer plugin to Raudikko

### DIFF
--- a/.docker/elasticsearch/Dockerfile
+++ b/.docker/elasticsearch/Dockerfile
@@ -1,14 +1,3 @@
-FROM elasticsearch:7.3.2
+FROM elasticsearch:7.17.6
 
-# Installation of the voikko library and plugin for ElasticSearch
-# https://github.com/EvidentSolutions/elasticsearch-analysis-voikko
-RUN yum install -y \
-    unzip \
-    libvoikko
-
-RUN curl -o /usr/lib64/voikko/morpho.zip https://www.puimula.org/htp/testing/voikko-snapshot/dict-morpho.zip
-RUN unzip -o /usr/lib64/voikko/morpho.zip -d /usr/lib64/voikko/
-
-RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://github.com/EvidentSolutions/elasticsearch-analysis-voikko/releases/download/v0.6.0/elasticsearch-analysis-voikko-0.6.0.zip \
-&& echo '-Djava.security.policy=file:/usr/share/elasticsearch/plugins/elasticsearch-analysis-voikko/plugin-security.policy' >> /usr/share/elasticsearch/config/jvm.options \
-|| echo "Plugin already exists."
+RUN bin/elasticsearch-plugin install https://github.com/EvidentSolutions/elasticsearch-analysis-raudikko/releases/download/v0.1.1/elasticsearch-analysis-raudikko-0.1.1-es7.17.6.zip

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
       - cluster.routing.allocation.disk.watermark.low=97%
       - cluster.routing.allocation.disk.watermark.high=98%
       - cluster.routing.allocation.disk.watermark.flood_stage=99%
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Djava.security.policy=file:/usr/share/elasticsearch/plugins/elasticsearch-analysis-voikko/plugin-security.policy"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     container_name: helerm_elasticsearch
 
   django:

--- a/search_indices/__init__.py
+++ b/search_indices/__init__.py
@@ -20,16 +20,16 @@ def get_edge_ngram_filter() -> token_filter:
     )
 
 
-def get_voikko_filter() -> token_filter:
+def get_raudikko_filter() -> token_filter:
     return token_filter(
-        "voikko",
-        type="voikko",
+        "raudikko",
+        type="raudikko",
     )
 
 
 def get_finnish_analyzer() -> analyzer:
     es_connection = create_elasticsearch_connection()
-    if "voikko" in es_connection.cat.plugins():
+    if "raudikko" in es_connection.cat.plugins():
         return analyzer(
             "finnish_analyzer",
             tokenizer="finnish",
@@ -38,7 +38,7 @@ def get_finnish_analyzer() -> analyzer:
                 "asciifolding",
                 "unique",
                 get_edge_ngram_filter(),
-                get_voikko_filter(),
+                get_raudikko_filter(),
             ],
         )
     else:


### PR DESCRIPTION
## Description

Switched ElasticSearch Finnish analyzer plugin from Voikko to Raudikko because Voikko has been deprecated and superseded by Raudikko.

## Related Issue(s)

**[TIED-72](https://helsinkisolutionoffice.atlassian.net/browse/TIED-72)**


[TIED-72]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ