### PR TITLE
Allow using authentication with ElasticSearch

### DIFF
--- a/.docker/django/.env.example
+++ b/.docker/django/.env.example
@@ -179,6 +179,10 @@ SENTRY_ENVIRONMENT=local-development-unconfigured
 # Host for ElasticSearch connection.
 ELASTICSEARCH_HOST=helerm_elasticsearch:9200
 
+# ElasticSearch credentials. Authentication won't be used unless both of these are set.
+ELASTICSEARCH_USERNAME=my_user
+ELASTICSEARCH_PASSWORD=my_password
+
 # Which analyzer will be used by elasticsearch. Default is to check if raudikko
 # plugin is available and use standard as a fallback. Probing can be skipped by setting
 # a specific analyzer.

--- a/config_dev.env.example
+++ b/config_dev.env.example
@@ -154,6 +154,10 @@ SENTRY_ENVIRONMENT=local-development-unconfigured
 # Host for ElasticSearch connection.
 # ELASTICSEARCH_HOST=helerm_elasticsearch:9200
 
+# ElasticSearch credentials. Authentication will be used when both of these are set.
+# ELASTICSEARCH_USERNAME=my_user
+# ELASTICSEARCH_PASSWORD=my_password
+
 # Which analyzer will be used by elasticsearch. Default is to check if raudikko
 # plugin is available and use standard as a fallback. Probing can be skipped by setting
 # a specific analyzer.

--- a/helerm/settings.py
+++ b/helerm/settings.py
@@ -68,6 +68,8 @@ env = environ.Env(
     INTERNAL_IPS=(list, []),
     HELERM_JHS191_EXPORT_DESCRIPTION=(str, "exported from undefined environment"),
     ELASTICSEARCH_HOST=(str, "helerm_elasticsearch:9200"),
+    ELASTICSEARCH_USERNAME=(str, ""),
+    ELASTICSEARCH_PASSWORD=(str, ""),
     ELASTICSEARCH_ANALYZER_MODE=(str, "probe"),
     SOCIAL_AUTH_TUNNISTAMO_KEY=(str, ""),
     SOCIAL_AUTH_TUNNISTAMO_SECRET=(str, ""),
@@ -332,7 +334,15 @@ OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
 
 # Elasticsearch configuration
 ELASTICSEARCH_DSL = {
-    "default": {"hosts": env("ELASTICSEARCH_HOST")},
+    "default": {
+        "hosts": env("ELASTICSEARCH_HOST"),
+        "http_auth": (
+            env("ELASTICSEARCH_USERNAME"),
+            env("ELASTICSEARCH_PASSWORD"),
+        )
+        if env("ELASTICSEARCH_USERNAME") and env("ELASTICSEARCH_PASSWORD")
+        else None,
+    },
 }
 
 # Name of the Elasticsearch index

--- a/search_indices/utils.py
+++ b/search_indices/utils.py
@@ -3,8 +3,7 @@ from elasticsearch_dsl import analyzer, connections, token_filter
 
 
 def create_elasticsearch_connection():
-    es_host = settings.ELASTICSEARCH_DSL["default"]["hosts"]
-    return connections.create_connection(hosts=[es_host])
+    return connections.create_connection(**settings.ELASTICSEARCH_DSL["default"])
 
 
 def get_finnish_stop_filter() -> token_filter:


### PR DESCRIPTION
## Description

Implemented optional authentication with ElasticSearch which is controlled by username and password env variables.

## Related Issue(s)

**[TIED-75](https://helsinkisolutionoffice.atlassian.net/browse/TIED-75)**

## Motivation and Context

Required by Platta.

## How Has This Been Tested?

Manually locally.



[TIED-75]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ