### PR TITLE
Switch to UBI Docker base image

### DIFF
--- a/.docker/django/Dockerfile
+++ b/.docker/django/Dockerfile
@@ -1,19 +1,18 @@
 # ==============================
-FROM python:3.9 AS appbase
+FROM registry.access.redhat.com/ubi9/python-39 as appbase
 # ==============================
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN useradd -Ums /bin/bash -d /appuser appuser
-
 WORKDIR /app
 
-COPY --chown=appuser:appuser requirements.txt .
+USER 0
 
-RUN apt-get update && apt-get install -y \
+COPY requirements.txt .
+
+RUN yum update -y && yum install -y \
     gettext \
-    postgresql-client \
     && pip install -U pip \
     && pip install --no-cache-dir -r requirements.txt
 
@@ -23,14 +22,16 @@ ENTRYPOINT ["/app/.docker/django/docker-entrypoint.sh"]
 FROM appbase AS development
 # ==============================
 
-COPY --chown=appuser:appuser requirements-dev.txt .
+COPY requirements-dev.txt .
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
 ENV DEV_SERVER=True
 
-COPY --chown=appuser:appuser . .
+COPY . .
 
-USER appuser
+# Openshift runs containers with a random user so to simulate that elsewhere
+# we use an arbitrary user
+USER 158435:0
 
 EXPOSE 8000/tcp
 
@@ -39,7 +40,7 @@ FROM appbase AS staticbuilder
 # ==============================
 
 ENV VAR_ROOT=/app
-COPY --chown=appuser:appuser . /app
+COPY . /app
 RUN ELASTICSEARCH_ANALYZER_MODE="raudikko" SECRET_KEY="only-used-for-collectstatic"  \
     python manage.py collectstatic --noinput
 
@@ -47,9 +48,11 @@ RUN ELASTICSEARCH_ANALYZER_MODE="raudikko" SECRET_KEY="only-used-for-collectstat
 FROM appbase AS production
 # ==============================
 
-COPY --from=staticbuilder --chown=appuser:appuser /app/static /app/static
-COPY --chown=appuser:appuser . .
+COPY --from=staticbuilder /app/static /app/static
+COPY . .
 
-USER appuser
+# Openshift runs containers with a random user so to simulate that elsewhere
+# we use an arbitrary user
+USER 158435:0
 
 EXPOSE 8000/tcp


### PR DESCRIPTION
## Description

Changed Docker base image to RedHat ubi9/python-39.

## Related Issue(s)

**[TIED-78](https://helsinkisolutionoffice.atlassian.net/browse/TIED-78)**

## Motivation and Context

The current recommendation for apps living in HKI Platta is to use UBI Docker base images.

## How Has This Been Tested?

Deployed to Platta dev env and manually checked this and that.