### PR TITLE
Change Docker compose Postgres host port

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: root
       POSTGRES_DB: helerm
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5555:5432"
     volumes:
       - helerm_postgres-data-volume:/var/lib/postgresql/data
     container_name: helerm_postgres


### PR DESCRIPTION
Changed Docker compose Postgres host port to 5555. The previous 5432 was easily colliding with a local Postgres instance which was not nice.