### PR TITLE
Increase uWSGI request max size to 32k

### DIFF
--- a/.docker/django/uwsgi_configuration.ini
+++ b/.docker/django/uwsgi_configuration.ini
@@ -11,6 +11,7 @@ master = 1
 processes = 2
 threads = 2
 socket-timeout = 60
+buffer-size = 32768
 
 # Suppress errors about clients closing sockets, happens when http pipes are closed
 # before workers have had the time to serve content to the pipe


### PR DESCRIPTION
The default request max size 4k is too small when Helsinki AD login method is used and the user belongs to a bunch of AD groups. 32k has proven to work in practice.