### PR TITLE
TIED-137 | Add instructions for using local tunnistamo instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # helerm - Helsinki Electronic Records Management Classification System
 
-[![Requirements](https://requires.io/github/City-of-Helsinki/helerm/requirements.svg?branch=master)](https://requires.io/github/City-of-Helsinki/helerm/requirements/?branch=master)
-
-
 ## Installation
 
 ### Manual setup
@@ -83,9 +80,9 @@ docker compose exec django python manage.py migrate
 
 ## Development
 
-- [pip-tools](https://github.com/nvie/pip-tools) is used to ease requirement handling. 
+- [pip-tools](https://github.com/nvie/pip-tools) is used to ease requirement handling.
   To install development packages, run
-  
+
 ```
 pip-sync requirements.txt requirements-dev.txt
 ```
@@ -115,8 +112,8 @@ python manage.py create_attributes
 python manage.py import_attributes <excel file>
 ```
 
-- Temporary step: the old data model requires a function object for every available 
-  function code even when there is no actual data for the function. Those initial  
+- Temporary step: the old data model requires a function object for every available
+  function code even when there is no actual data for the function. Those initial
   functions can be created based on current classification by running
 
 ```
@@ -136,7 +133,7 @@ python manage.py import_template <data excel file> <sheet name> [template name]
 ```
 
 ## Export
- 
+
 - All data can be exported to a XML file by running
 
 ```
@@ -144,3 +141,58 @@ python manage.py export_data <xml file>
 ```
 
 - Or using the API http://127.0.0.1:8080/export/
+
+## Using local Tunnistamo instance for development with docker
+
+### Set tunnistamo hostname
+
+Add the following line to your hosts file (`/etc/hosts` on mac and linux):
+
+    127.0.0.1 tunnistamo-backend
+
+### Create a new OAuth app on GitHub
+
+Go to https://github.com/settings/developers/ and add a new app with the following settings:
+
+- Application name: can be anything, e.g. local tunnistamo
+- Homepage URL: http://tunnistamo-backend:8000
+- Authorization callback URL: http://tunnistamo-backend:8000/accounts/github/login/callback/
+
+Save. You'll need the created **Client ID** and **Client Secret** for configuring tunnistamo in the next step.
+
+### Install local tunnistamo
+
+Clone https://github.com/City-of-Helsinki/tunnistamo/.
+
+Follow the instructions for setting up tunnistamo locally. Before running `docker compose up` set the following settings in tunnistamo roots `docker-compose.env.yaml`:
+
+- SOCIAL_AUTH_GITHUB_KEY: **Client ID** from the GitHub OAuth app
+- SOCIAL_AUTH_GITHUB_SECRET: **Client Secret** from the GitHub OAuth app
+
+After you've got tunnistamo running locally, ssh to the tunnistamo docker container:
+
+`docker compose exec django bash`
+
+and execute the following four commands inside your docker container:
+
+```bash
+./manage.py add_oidc_client -n helerm-api -t "code" -u http://localhost:8080/pysocial/complete/tunnistamo/ -i https://api.hel.fi/auth/helerm -m github -s dev -c
+./manage.py add_oidc_client -n helerm-api-admin -t "code" -u http://localhost:8080/pysocial/complete/tunnistamo/ -i helerm-api-admin -m github -s dev -c
+./manage.py add_oidc_client -n helerm-ui -t "id_token token" -u "http://localhost:3000/callback" "http://localhost:3000/renew" -i helerm-ui -m github -s dev
+./manage.py add_oidc_api -n helerm -d https://api.hel.fi/auth -s email,profile -c https://api.hel.fi/auth/helerm
+./manage.py add_oidc_api_scope -an helerm -c https://api.hel.fi/auth/helerm -n "helerm" -d "Lorem ipsum"
+./manage.py add_oidc_client_to_api_scope -asi https://api.hel.fi/auth/helerm -c helerm-api-admin
+./manage.py add_oidc_client_to_api_scope -asi https://api.hel.fi/auth/helerm -c helerm-ui
+```
+
+### Configure Tunnistamo to backend
+
+Change the following configuration in `.docker/django/.env`
+
+```
+SOCIAL_AUTH_TUNNISTAMO_KEY=helerm-api-admin
+SOCIAL_AUTH_TUNNISTAMO_SECRET=<helerm-api-admin client secret from Tunnistamo here>
+SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT=http://tunnistamo-backend:8000/openid
+OIDC_API_TOKEN_AUTH_AUDIENCE=https://api.hel.fi/auth/helerm
+OIDC_API_TOKEN_AUTH_ISSUER=http://tunnistamo-backend:8000/openid
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,3 +46,7 @@ services:
 
 volumes:
   helerm_postgres-data-volume:
+
+networks:
+    default:
+        name: helsinki


### PR DESCRIPTION
- Add instructions for setting up the local Tunnistamo instance correctly
- Add a fix to `compose.yaml` enabling the backend to fetch authentication configuration from locally running Tunnistamo instance