### PR TITLE
Add commit message format requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
           linters: isort
           run: isort . --check-only --diff
 
+      - name: Check commitlint
+        uses: wagoid/commitlint-github-action@0d749a1a91d4770e983a7b8f83d4a3f0e7e0874e  # v5.4.4
+
       - name: Run tests
         uses: liskin/gh-problem-matcher-wrap@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # Keep tool versions in sync with the versions in requirements-dev.txt
 default_language_version:
     python: python3
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit, manual]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -25,3 +27,9 @@ repos:
     hooks:
       - id: isort
         exclude: "migrations"
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.8.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg, manual]
+        additional_dependencies: ["@commitlint/config-conventional"]

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ python manage.py export_data <xml file>
 
 - Or using the API http://127.0.0.1:8080/export/
 
+## Commit message format
+
+New commit messages must adhere to the [Conventional Commits](https://www.conventionalcommits.org/)
+specification, and line length is limited to 72 characters.
+
+When [`pre-commit`](https://pre-commit.com/) is in use, [`commitlint`](https://github.com/conventional-changelog/commitlint)
+checks new commit messages for the correct format.
+
 ## Using local Tunnistamo instance for development with docker
 
 ### Set tunnistamo hostname

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+const Configuration = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 72],
+    'body-leading-blank': [2, 'always'],
+  },
+};
+
+module.exports = Configuration;


### PR DESCRIPTION
## Description

From now on, all new commit messages must adhere to the [conventional commits spec](https://www.conventionalcommits.org/en/v1.0.0/) and their max line length is limited to 72 characters. The rules are enforced with [commitlint](https://commitlint.js.org/#/), which is run as a pre-commit hook and also as a stage in the GitHub CI pipeline.

## Related Issue(s)

**[TIED-139](https://helsinkisolutionoffice.atlassian.net/browse/TIED-139)**

## Motivation and Context

We plan to increasingly adopt Conventional Commits in our projects.

## How Has This Been Tested?

Manually and the CI pipeline passes.


[TIED-139]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ