### PR TITLE
Increase uWSGI harakiri timeout

### DIFF
--- a/.docker/django/uwsgi_configuration.ini
+++ b/.docker/django/uwsgi_configuration.ini
@@ -2,7 +2,7 @@
 # https://uwsgi-docs.readthedocs.io/en/latest/Options.html
 
 http = :8000
-http-timeout = 60
+http-timeout = 175
 wsgi-file = helerm/wsgi.py
 static-map = /static=/app/static
 uid = nobody
@@ -18,8 +18,9 @@ buffer-size = 65535
 # this makes container slow to stop, so we change it here
 die-on-term = true
 
-# Kill a worker after 120 seconds of processing a request
-harakiri = 120
+# Kill a worker after 175 seconds of processing a request
+# 175 was chosen to make sure this is hit before Openshift haxproxy timeout, which is 180 seconds
+harakiri = 175
 harakiri-graceful-timeout = 5
 
 # Reload workers regularly to keep memory fresh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Spin up ES with Raudikko
         run: |
           touch .docker/django/.env
-          docker-compose up -d elasticsearch
+          docker compose up -d elasticsearch
 
       - name: psycopg2 prerequisites
         run: sudo apt-get install libpq-dev


### PR DESCRIPTION
It was reported that some large function update requests in production are hitting timeouts, so as a quick patch increased uWSGI harakiri timeout to 175 seconds. To avoid client erroring while processing is still going on in the backend, the timeout was set to a lower value than Openshift haproxy timeout 180 seconds (which seems to be the max value for that).

## Related Issue(s)

**[TIED-159](https://helsinkisolutionoffice.atlassian.net/browse/TIED-159)**