### PR TITLE
feat: restrict filtering for information system for unauth users

### DIFF
--- a/metarecord/views/function.py
+++ b/metarecord/views/function.py
@@ -418,6 +418,15 @@ class FunctionFilterSet(django_filters.FilterSet):
         lookup_expr="icontains",
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Restrict querying information system queries to authenticated users.
+        # The information system field contents are not public.
+        user = getattr(self.request, "user", None)
+        if not user or not user.is_authenticated:
+            self.filters.pop("information_system", None)
+
     def filter_valid_at(self, queryset, name, value):
         # if neither date is set the function is considered not valid
         queryset = queryset.exclude(

--- a/search_indices/tests/conftest.py
+++ b/search_indices/tests/conftest.py
@@ -90,6 +90,13 @@ def action(phase):
 
 
 @fixture
+def action_2(phase_2):
+    return Action.objects.create(
+        attributes={"AdditionalInformation": "testisana"}, phase=phase_2, index=1
+    )
+
+
+@fixture
 def classification():
     return Classification.objects.create(
         title="testisana",
@@ -100,7 +107,7 @@ def classification():
 
 
 @fixture
-def classification2():
+def classification_2():
     return Classification.objects.create(
         title="testisana ja toinen testisana",
         code="00 00",
@@ -118,6 +125,14 @@ def function(classification):
 
 
 @fixture
+def function_2(classification_2):
+    return Function.objects.create(
+        attributes={"AdditionalInformation": "testword"},
+        classification=classification_2,
+    )
+
+
+@fixture
 def phase(function):
     return Phase.objects.create(
         attributes={"AdditionalInformation": "testisana"}, function=function, index=1
@@ -125,7 +140,28 @@ def phase(function):
 
 
 @fixture
+def phase_2(function_2):
+    return Phase.objects.create(
+        attributes={"AdditionalInformation": "testword"}, function=function_2, index=1
+    )
+
+
+@fixture
 def record(action):
     return Record.objects.create(
         attributes={"AdditionalInformation": "testisana"}, action=action, index=1
+    )
+
+
+@fixture
+def record_with_information_system(action):
+    return Record.objects.create(
+        attributes={"InformationSystem": "xyz"}, action=action, index=1
+    )
+
+
+@fixture
+def record_2(action_2):
+    return Record.objects.create(
+        attributes={"AdditionalInformation": "testword"}, action=action_2, index=1
     )

--- a/search_indices/views/base.py
+++ b/search_indices/views/base.py
@@ -67,3 +67,11 @@ class BaseSearchDocumentViewSet(BaseDocumentViewSet):
         "type",
         "_score",
     )
+
+    def filter_queryset(self, queryset):
+        # Restrict querying information system queries to authenticated users.
+        # The information system field contents are not public.
+        if not self.request.user.is_authenticated:
+            self.filter_fields.pop("record_InformationSystem", None)
+
+        return super().filter_queryset(queryset)


### PR DESCRIPTION
The information system field content already has a restricted visibility for unauthenticated users and so should be the filtering options for that field be.

Refs TIED-171

