### PR TITLE
feat: restrict information_system from facets for unauthenticated

### DIFF
--- a/search_indices/tests/test_elastic_api.py
+++ b/search_indices/tests/test_elastic_api.py
@@ -461,3 +461,38 @@ class TestInformationSystemAttributeListUrls:
         assert response.status_code == 200
         assert phase_with_information_system.uuid.hex in uuids
         assert phase_2.uuid.hex in uuids
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "list_url",
+    [
+        PHASE_LIST_URL,
+        ACTION_LIST_URL,
+        RECORD_LIST_URL,
+        FUNCTION_LIST_URL,
+        ALL_LIST_URL,
+    ],
+)
+class TestInformationSystemInFacets:
+    def test_list_for_authenticated(
+        self,
+        user_api_client,
+        list_url,
+    ):
+        response = user_api_client.get(list_url)
+        facets = response.data["facets"] if "facets" in response.data else response.data
+
+        assert response.status_code == 200
+        assert "informationsystem" in "".join([key.lower() for key in facets])
+
+    def test_list_for_unauthenticated(
+        self,
+        api_client,
+        list_url,
+    ):
+        response = api_client.get(list_url)
+        facets = response.data["facets"] if "facets" in response.data else response.data
+
+        assert response.status_code == 200
+        assert "informationsystem" not in "".join([key.lower() for key in facets])

--- a/search_indices/views/action.py
+++ b/search_indices/views/action.py
@@ -10,7 +10,9 @@ class ActionSearchDocumentViewSet(BaseSearchDocumentViewSet):
     serializer_class = ActionSearchSerializer
 
     filter_fields = {}
-    attributes = FacetedAttributeBackend.get_attributes([ActionDocument])
-    populate_filter_fields_with_attributes(filter_fields, attributes)
+    base_attributes = FacetedAttributeBackend.get_attributes([ActionDocument])
+    populate_filter_fields_with_attributes(filter_fields, base_attributes)
 
-    search_fields = tuple(f"attributes.{attribute}" for attribute in attributes)
+    base_search_fields = tuple(
+        f"attributes.{attribute}" for attribute in base_attributes
+    )

--- a/search_indices/views/classification.py
+++ b/search_indices/views/classification.py
@@ -15,7 +15,7 @@ class ClassificationSearchDocumentViewSet(BaseSearchDocumentViewSet):
         "additional_information": "additional_information",
     }
 
-    search_fields = (
+    base_search_fields = (
         "title",
         "description",
         "related_classification",

--- a/search_indices/views/function.py
+++ b/search_indices/views/function.py
@@ -10,7 +10,9 @@ class FunctionSearchDocumentViewSet(BaseSearchDocumentViewSet):
     serializer_class = FunctionSearchSerializer
 
     filter_fields = {}
-    attributes = FacetedAttributeBackend.get_attributes([FunctionDocument])
-    populate_filter_fields_with_attributes(filter_fields, attributes)
+    base_attributes = FacetedAttributeBackend.get_attributes([FunctionDocument])
+    populate_filter_fields_with_attributes(filter_fields, base_attributes)
 
-    search_fields = tuple(f"attributes.{attribute}" for attribute in attributes)
+    base_search_fields = tuple(
+        f"attributes.{attribute}" for attribute in base_attributes
+    )

--- a/search_indices/views/phase.py
+++ b/search_indices/views/phase.py
@@ -10,7 +10,9 @@ class PhaseSearchDocumentViewSet(BaseSearchDocumentViewSet):
     serializer_class = PhaseSearchSerializer
 
     filter_fields = {}
-    attributes = FacetedAttributeBackend.get_attributes([PhaseDocument])
-    populate_filter_fields_with_attributes(filter_fields, attributes)
+    base_attributes = FacetedAttributeBackend.get_attributes([PhaseDocument])
+    populate_filter_fields_with_attributes(filter_fields, base_attributes)
 
-    search_fields = tuple(f"attributes.phase_{attribute}" for attribute in attributes)
+    base_search_fields = tuple(
+        f"attributes.phase_{attribute}" for attribute in base_attributes
+    )

--- a/search_indices/views/record.py
+++ b/search_indices/views/record.py
@@ -10,7 +10,9 @@ class RecordSearchDocumentViewSet(BaseSearchDocumentViewSet):
     serializer_class = RecordSearchSerializer
 
     filter_fields = {}
-    attributes = FacetedAttributeBackend.get_attributes([RecordDocument])
-    populate_filter_fields_with_attributes(filter_fields, attributes)
+    base_attributes = FacetedAttributeBackend.get_attributes([RecordDocument])
+    populate_filter_fields_with_attributes(filter_fields, base_attributes)
 
-    search_fields = tuple(f"attributes.{attribute}" for attribute in attributes)
+    base_search_fields = tuple(
+        f"attributes.{attribute}" for attribute in base_attributes
+    )

--- a/search_indices/views/utils.py
+++ b/search_indices/views/utils.py
@@ -1,11 +1,19 @@
+from search_indices.serializers.utils import attributes_for_authenticated
+
+
 def populate_filter_fields_with_attributes(
-    filter_fields: dict, attributes: list
+    filter_fields: dict, attributes: list, exclude_information_system: bool = False
 ) -> None:
     """
     Fetch the filter fields from the indexed attributes.
     """
     if not attributes:
         return
+
+    if exclude_information_system:
+        for attribute in attributes_for_authenticated:
+            filter_fields.pop(attribute, None)
+
     for attribute in attributes:
         attribute_replaced = attribute.replace(".", "+")
         # Example {"Subject.Scheme": "attributes.Subject+Scheme"}


### PR DESCRIPTION
There are also information system information in search facets which are to be restricted from the unauthenticated users.

Removes InformationSystem attributes from facets data for unauthenticated users.

Refs TIED-171


