### PR TITLE
feat: use django-helsinki-health-endpoints for readiness and healthz

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,4 @@
 !LICENSE
 !manage.py
 !requirements*.txt
+!pyproject.toml

--- a/helerm/settings.py
+++ b/helerm/settings.py
@@ -139,7 +139,11 @@ INSTALLED_APPS = [
     "metarecord",
     "search_indices",
     "users",
+    "helsinki_health_endpoints",
 ]
+
+# Django helsinki health endpoitns
+SENTRY_RELEASE = env.str("SENTRY_RELEASE")
 
 SENTRY_TRACES_SAMPLE_RATE = env.float("SENTRY_TRACES_SAMPLE_RATE")
 SENTRY_TRACES_IGNORE_PATHS = env("SENTRY_TRACES_IGNORE_PATHS")
@@ -163,7 +167,7 @@ if env("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=env.str("SENTRY_DSN"),
         environment=env.str("SENTRY_ENVIRONMENT"),
-        release=env.str("SENTRY_RELEASE"),
+        release=SENTRY_RELEASE,
         integrations=[DjangoIntegration()],
         traces_sampler=sentry_traces_sampler,
         profile_session_sample_rate=env.str("SENTRY_PROFILE_SESSION_SAMPLE_RATE"),

--- a/helerm/tests/test_urls.py
+++ b/helerm/tests/test_urls.py
@@ -1,8 +1,12 @@
+import pytest
+
+
 def test_healthz(client):
     response = client.get("/healthz")
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
 def test_readiness(client):
     response = client.get("/readiness")
     assert response.status_code == 200

--- a/helerm/urls.py
+++ b/helerm/urls.py
@@ -1,8 +1,5 @@
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import include, path
-from django.views.decorators.cache import never_cache
-from django.views.decorators.http import require_safe
 from django.views.generic import RedirectView
 from rest_framework.routers import DefaultRouter
 
@@ -49,28 +46,12 @@ router.register(r"record-search", RecordSearchDocumentViewSet, basename="record_
 router.register(r"all-search", AllSearchDocumentViewSet, basename="all_search")
 
 
-#
-# Kubernetes liveness & readiness probes
-#
-@require_safe
-@never_cache
-def healthz(*_, **__):
-    return HttpResponse(status=200)
-
-
-@require_safe
-@never_cache
-def readiness(*_, **__):
-    return HttpResponse(status=200)
-
-
 urlpatterns = [
-    path("healthz", healthz),
-    path("readiness", readiness),
     path("v1/", include(router.urls)),
     path("admin/", admin.site.urls),
     path("pysocial/", include("social_django.urls", namespace="social")),
     path("helauth/", include("helusers.urls")),
     path("export/", ExportView.as_view(), name="export"),
     path("", RedirectView.as_view(url="v1/")),
+    path("", include("helsinki_health_endpoints.urls")),
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ django-cors-headers
 django-filter
 django-admin-json-editor
 django-admin-sortable2
+django-helsinki-health-endpoints
 djangorestframework-xml
 ipython
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -267,6 +267,7 @@ django==5.2.12 \
     #   django-admin-sortable2
     #   django-cors-headers
     #   django-filter
+    #   django-helsinki-health-endpoints
     #   django-helusers
     #   django-nine
     #   djangorestframework
@@ -297,6 +298,10 @@ django-environ==0.12.0 \
 django-filter==25.1 \
     --hash=sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153 \
     --hash=sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80
+    # via -r requirements.in
+django-helsinki-health-endpoints==1.0.0 \
+    --hash=sha256:75670113e99bfd1fc23e317a3a22cff563140f495655c2a5f6ab219389dafd52 \
+    --hash=sha256:eebf1baa6917d7b0e11123aec191df773883102ec1653025a86d7037dba389e2
     # via -r requirements.in
 django-helusers==1.0.0 \
     --hash=sha256:0e33e238347a4088927675574a7dad179ee1f9d9e958daecfa4862ad6f63f79c \


### PR DESCRIPTION
Make use of django-helsinki-health-endpoints library to publish readiness and healthz endpoints.

Add SENTRY_RELEASE to django settings from env for the library and make sure that pyproject.toml isn't excluded from the container. Those are requisite for the readiness data.

Refs: KEH-242
