### PR TITLE
Allow multiple SecurityReason values

### DIFF
--- a/data/Skeema_TOS_kooste_HKI_custom.xsd
+++ b/data/Skeema_TOS_kooste_HKI_custom.xsd
@@ -232,7 +232,7 @@ xx.04.2014: palautekierrosten perusteella muokattu versio
 			<xs:element ref="tos:TurvallisuusluokkaKoodi" minOccurs="0"/>
 			<xs:element ref="tos:HenkilotietoluonneKoodi" minOccurs="0"/>
 			<xs:element ref="tos:SalassapitoAikaArvo" minOccurs="0"/>
-			<xs:element ref="tos:SalassapitoPerusteTeksti" minOccurs="0"/>
+			<xs:element ref="tos:SalassapitoPerusteTeksti" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="tos:SalassapidonLaskentaperusteTeksti" minOccurs="0"/>
 			<xs:element ref="tos:Laajennos" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>

--- a/metarecord/exporter/jhs/builder.py
+++ b/metarecord/exporter/jhs/builder.py
@@ -69,31 +69,38 @@ def _create_element_or_none_from_obj_attr(obj, element, attr: str):
     """
     Create an element from the given attribute of the given object.
     If the attribute is None, return None instead.
+    If the attribute is a list, return a list of elements.
 
     :param obj: The object to get the attribute from
     :param element: The element to create
     :param attr: The attribute to get the value from
-    :return: The created element or None
+    :return: The created element, a list of elements, or None
     """
     value = _get_attribute_value(obj, attr)
     if value is None:
         return None
+    if isinstance(value, list):
+        return [element(v) for v in value]
     return element(value)
 
 
 def _generate_elements_from_obj(obj, element_to_attribute: dict):
     """
     Generate elements from the given attributes of the given object.
+    If an attribute value is a list, a separate element is created for each item.
 
     :param obj: The object to get the attributes from
     :param element_to_attribute: A dictionary mapping elements to attributes
     :return: A list of elements
     """
-    elements = [
-        _create_element_or_none_from_obj_attr(obj, elem, attr)
-        for elem, attr in element_to_attribute.items()
-    ]
-    return elements
+    result = []
+    for element, attribute in element_to_attribute.items():
+        value = _create_element_or_none_from_obj_attr(obj, element, attribute)
+        if isinstance(value, list):
+            result.extend(value)
+        else:
+            result.append(value)
+    return result
 
 
 def _build_restriction_info(obj):

--- a/metarecord/models/function.py
+++ b/metarecord/models/function.py
@@ -127,7 +127,7 @@ class Function(StructuralElement):
         "conditionally_disallowed": {
             "RetentionPeriodStart": {"RetentionPeriod": ("-1",)}
         },
-        "multivalued": ("InformationSystem", "Subject"),
+        "multivalued": ("InformationSystem", "SecurityReason", "Subject"),
         "allow_values_outside_choices": ("InformationSystem", "Subject"),
     }
 

--- a/metarecord/models/record.py
+++ b/metarecord/models/record.py
@@ -74,7 +74,7 @@ class Record(StructuralElement):
         "conditionally_disallowed": {
             "RetentionPeriodStart": {"RetentionPeriod": ("-1",)}
         },
-        "multivalued": ("InformationSystem", "Subject"),
+        "multivalued": ("InformationSystem", "SecurityReason", "Subject"),
         "allow_values_outside_choices": ("InformationSystem", "Subject"),
     }
 

--- a/metarecord/tests/test_jhs_exporter.py
+++ b/metarecord/tests/test_jhs_exporter.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import freezegun
 import pytest
-from lxml import etree
+from lxml import etree, objectify
 from rest_framework.test import APIClient
 
 import metarecord.exporter.jhs as jhs
@@ -200,3 +200,60 @@ def test_exporter_create_xml_error_during_build():
 def test_fix_xml_declaration(xml_declaration, expected):
     """Test that fix_xml_declaration fixes the XML declaration."""
     assert jhs.exporter.fix_xml_declaration_single_quotes(xml_declaration) == expected
+
+
+def _get_tag(element):
+    return etree.QName(element.tag).localname
+
+
+def test_create_element_or_none_returns_list_of_elements_for_list_value():
+    """Test that a list attribute value produces a list of elements."""
+    obj = mock.Mock(attributes={"SecurityReason": ["JulkL 24.1 § 1 k", "JulkL 24.1 § 3 k"]})
+    result = jhs.builder._create_element_or_none_from_obj_attr(
+        obj, jhs.bindings.SALASSAPITO_PERUSTE_TEKSTI, "SecurityReason"
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(_get_tag(el) == "SalassapitoPerusteTeksti" for el in result)
+    assert result[0].text == "JulkL 24.1 § 1 k"
+    assert result[1].text == "JulkL 24.1 § 3 k"
+
+
+def test_create_element_or_none_returns_single_element_for_string_value():
+    """Test that a string attribute value still produces a single element."""
+    obj = mock.Mock(attributes={"SecurityReason": "JulkL 24.1 § 1 k"})
+    result = jhs.builder._create_element_or_none_from_obj_attr(
+        obj, jhs.bindings.SALASSAPITO_PERUSTE_TEKSTI, "SecurityReason"
+    )
+    assert not isinstance(result, list)
+    assert _get_tag(result) == "SalassapitoPerusteTeksti"
+    assert result.text == "JulkL 24.1 § 1 k"
+
+
+def test_build_restriction_info_produces_multiple_security_reason_elements():
+    """Test that a list SecurityReason produces one element per value in the XML."""
+    obj = mock.Mock(
+        attributes={
+            "SecurityReason": ["JulkL 24.1 § 1 k", "JulkL 24.1 § 3 k"],
+        }
+    )
+    restriction = jhs.builder._build_restriction_info(obj)
+    security_reason_elements = [
+        el for el in restriction.iterchildren()
+        if _get_tag(el) == "SalassapitoPerusteTeksti"
+    ]
+    assert len(security_reason_elements) == 2
+    assert security_reason_elements[0].text == "JulkL 24.1 § 1 k"
+    assert security_reason_elements[1].text == "JulkL 24.1 § 3 k"
+
+
+def test_build_restriction_info_single_security_reason_still_works():
+    """Test that a single string SecurityReason still produces one element."""
+    obj = mock.Mock(attributes={"SecurityReason": "JulkL 24.1 § 1 k"})
+    restriction = jhs.builder._build_restriction_info(obj)
+    security_reason_elements = [
+        el for el in restriction.iterchildren()
+        if _get_tag(el) == "SalassapitoPerusteTeksti"
+    ]
+    assert len(security_reason_elements) == 1
+    assert security_reason_elements[0].text == "JulkL 24.1 § 1 k"


### PR DESCRIPTION
Related frontend PR: https://github.com/City-of-Helsinki/helerm-ui/pull/678

Refs: TIED-288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XML exports now support multiple security or confidentiality reasons for a single record.
  * Each specified reason is exported as a separate, clearly labeled XML element.
  * Records can now include multiple values for applicable information systems, subjects, and security reasons.

* **Bug Fixes**
  * Improved XML generation for multi-valued attributes while preserving existing single-value and empty-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->